### PR TITLE
Rewrite functions for FHIR Renderer for all classes using smart-on-fhir client

### DIFF
--- a/chord_metadata_service/chord/serializers.py
+++ b/chord_metadata_service/chord/serializers.py
@@ -3,7 +3,7 @@ from chord_metadata_service.restapi.serializers import GenericSerializer
 from jsonschema import Draft7Validator, Draft4Validator
 from rest_framework import serializers
 from chord_metadata_service.restapi.dats_schemas import get_dats_schema, CREATORS
-from chord_metadata_service.restapi.fhir_utils import transform_keys
+from chord_metadata_service.restapi.utils import transform_keys
 
 from .models import *
 

--- a/chord_metadata_service/patients/serializers.py
+++ b/chord_metadata_service/patients/serializers.py
@@ -7,7 +7,7 @@ from chord_metadata_service.phenopackets.serializers import (
 from chord_metadata_service.restapi.schemas import ONTOLOGY_CLASS, AGE_OR_AGE_RANGE
 from chord_metadata_service.restapi.validators import JsonSchemaValidator
 from chord_metadata_service.restapi.serializers import GenericSerializer
-from chord_metadata_service.restapi.fhir_utils import individual_to_fhir
+from chord_metadata_service.restapi.fhir_utils import fhir_patient
 
 
 class IndividualSerializer(GenericSerializer):
@@ -32,4 +32,4 @@ class IndividualSerializer(GenericSerializer):
 		fields = '__all__'
 		# meta info for converting to FHIR
 		fhir_datatype_plural = 'patients'
-		class_converter = individual_to_fhir
+		class_converter = fhir_patient

--- a/chord_metadata_service/patients/tests/constants.py
+++ b/chord_metadata_service/patients/tests/constants.py
@@ -38,3 +38,17 @@ INVALID_INDIVIDUAL = {
     "sex": "FEM",
     "active": True
 }
+
+VALID_INDIVIDUAL_2 = {
+    "id": "patient:2",
+    "taxonomy": {
+        "id": "NCBITaxon:9606",
+        "label": "human"
+    },
+    "date_of_birth": "1967-01-01",
+    "age": {
+        "age": "P55Y"
+    },
+    "sex": "MALE",
+    "active": True
+}

--- a/chord_metadata_service/phenopackets/serializers.py
+++ b/chord_metadata_service/phenopackets/serializers.py
@@ -179,7 +179,7 @@ class DiseaseSerializer(GenericSerializer):
 		fields = '__all__'
 		# meta info for converting to FHIR
 		fhir_datatype_plural = 'conditions'
-		class_converter = disease_to_fhir
+		class_converter = fhir_condition
 
 	def validate_disease_stage(self, value):
 		if isinstance(value, list):

--- a/chord_metadata_service/phenopackets/serializers.py
+++ b/chord_metadata_service/phenopackets/serializers.py
@@ -147,7 +147,7 @@ class VariantSerializer(GenericSerializer):
 		fields = '__all__'
 		# meta info for converting to FHIR
 		fhir_datatype_plural = 'observations'
-		class_converter = variant_to_fhir
+		class_converter = fhir_obs_component_variant
 
 	def to_representation(self, obj):
 		""" Change 'allele_type' field name to allele type value. """

--- a/chord_metadata_service/phenopackets/serializers.py
+++ b/chord_metadata_service/phenopackets/serializers.py
@@ -219,7 +219,7 @@ class BiosampleSerializer(GenericSerializer):
 		fields = '__all__'
 		# meta info for converting to FHIR
 		fhir_datatype_plural = 'specimens'
-		class_converter = biosample_to_fhir
+		class_converter = fhir_specimen
 
 	def validate_diagnostic_markers(self, value):
 		if isinstance(value, list):

--- a/chord_metadata_service/phenopackets/serializers.py
+++ b/chord_metadata_service/phenopackets/serializers.py
@@ -131,8 +131,8 @@ class GeneSerializer(GenericSerializer):
 		model = Gene
 		fields = '__all__'
 		# meta info for converting to FHIR
-		fhir_datatype_plural = 'genes_studied'
-		class_converter = fhir_obs_region_studied
+		fhir_datatype_plural = 'observations'
+		class_converter = fhir_obs_component_region_studied
 
 
 class VariantSerializer(GenericSerializer):

--- a/chord_metadata_service/phenopackets/serializers.py
+++ b/chord_metadata_service/phenopackets/serializers.py
@@ -78,7 +78,7 @@ class PhenotypicFeatureSerializer(GenericSerializer):
 		exclude = ['pftype']
 		# meta info for converting to FHIR
 		fhir_datatype_plural = 'observations'
-		class_converter = phenotypic_feature_to_fhir
+		class_converter = fhir_observation
 
 	def validate_modifier(self, value):
 		if isinstance(value, list):

--- a/chord_metadata_service/phenopackets/serializers.py
+++ b/chord_metadata_service/phenopackets/serializers.py
@@ -247,7 +247,7 @@ class SimplePhenopacketSerializer(GenericSerializer):
 		fields = '__all__'
 		# meta info for converting to FHIR
 		fhir_datatype_plural = 'compositions'
-		class_converter = phenopacket_to_fhir
+		class_converter = fhir_composition
 
 
 	def to_representation(self, instance):

--- a/chord_metadata_service/phenopackets/serializers.py
+++ b/chord_metadata_service/phenopackets/serializers.py
@@ -100,8 +100,8 @@ class ProcedureSerializer(GenericSerializer):
 		model = Procedure
 		fields = '__all__'
 		# meta info for converting to FHIR
-		fhir_datatype_plural = 'procedures'
-		class_converter = procedure_to_fhir
+		fhir_datatype_plural = 'specimen.collections'
+		class_converter = fhir_specimen_collection
 
 	def create(self, validated_data):
 		if validated_data.get('body_site'):

--- a/chord_metadata_service/phenopackets/serializers.py
+++ b/chord_metadata_service/phenopackets/serializers.py
@@ -119,7 +119,7 @@ class HtsFileSerializer(GenericSerializer):
 		fields = '__all__'
 		# meta info for converting to FHIR
 		fhir_datatype_plural = 'document_references'
-		class_converter = hts_file_to_fhir
+		class_converter = fhir_document_reference
 
 
 class GeneSerializer(GenericSerializer):

--- a/chord_metadata_service/phenopackets/serializers.py
+++ b/chord_metadata_service/phenopackets/serializers.py
@@ -131,8 +131,8 @@ class GeneSerializer(GenericSerializer):
 		model = Gene
 		fields = '__all__'
 		# meta info for converting to FHIR
-		fhir_datatype_plural = 'codeable_concepts'
-		class_converter = gene_to_fhir
+		fhir_datatype_plural = 'genes_studied'
+		class_converter = fhir_obs_region_studied
 
 
 class VariantSerializer(GenericSerializer):

--- a/chord_metadata_service/restapi/fhir_utils.py
+++ b/chord_metadata_service/restapi/fhir_utils.py
@@ -292,32 +292,6 @@ def fhir_obs_component_variant(obj):
 	return component.as_json()
 
 
-def disease_to_fhir(obj):
-	""" Disease to FHIR Condition. """
-
-	disease_record = {}
-	disease_record['resourceType'] = 'Condition'
-	disease_record['code'] = []
-	coding = {}
-	coding['coding'] = []
-	coding['coding'].append(fhir_coding(obj, 'term'))
-	disease_record['code'].append(coding)
-	if obj.get('onset'):
-		disease_record['onsetAge'] = {}
-		disease_record['onsetAge']['code'] = obj.get('onset', {}).get('age', None)
-	disease_stages = obj.get('disease_stage', None)
-	if disease_stages:
-		disease_record['stage'] = []
-		stage_type = {}
-		stage_type['type'] = {}
-		stage_type['type']['coding'] = []
-		for coding in disease_stages:
-			coding = fhir_coding(coding)
-			stage_type['type']['coding'].append(coding)
-		disease_record['stage'].append(stage_type)
-	return disease_record
-
-
 def check_disease_onset(disease):
 	"""
 	Phenopackets schema allows age to be represented by ISO8601 string,

--- a/chord_metadata_service/restapi/fhir_utils.py
+++ b/chord_metadata_service/restapi/fhir_utils.py
@@ -37,6 +37,8 @@ def transform_keys(obj):
 
 
 def fhir_patient(obj):
+	""" Converts Individual to FHIR Patient. """
+
 	patient = p.Patient()
 	patient.id = obj.get('id', None)
 	patient.birthDate = FHIRDate(obj.get('date_of_birth', None))
@@ -73,33 +75,6 @@ def fhir_patient(obj):
 	taxonomy_extension.valueCodeableConcept.coding.append(coding)
 	patient.extension.append(taxonomy_extension)
 	return patient.as_json()
-
-
-def individual_to_fhir(obj):
-	""" Transform individual data to Patient FHIR record. """
-
-	fhir_record = {}
-	fhir_record['resourceType'] = 'Patient'
-	# mapping for basic Patient attributes
-	mapping = {
-	'id': 'identifier',
-	'date_of_birth': 'birthDate',
-	'sex': 'gender',
-	'active': 'active',
-	'deceased': 'deceased',
-	'race': 'race',
-	'ethnicity': 'ethnicity'
-	}
-	for field in mapping.keys():
-		if field in obj.keys():
-			fhir_record[mapping.get(field)] = obj.get(field, None)
-	# mapping for biosamples assosiated with this patient
-	if 'biosamples' in obj.keys():
-		fhir_record['biosamples'] = []
-		for sample in obj.get('biosamples', None):
-			biosample_record = biosample_to_fhir(sample)
-			fhir_record['biosamples'].append(biosample_record)
-	return fhir_record
 
 
 def fhir_coding(obj, value=None):
@@ -145,6 +120,8 @@ def codeable_concepts_fields(field_list, obj):
 		
 
 def fhir_observation(obj):
+	""" Converts phenotypic feature to FHIR Observation. """
+
 	observation = obs.Observation()
 	if 'description' in obj.keys():
 		observation.note = []
@@ -197,56 +174,9 @@ def fhir_observation(obj):
 	return observation.as_json()
 
 
-def phenotypic_feature_to_fhir(obj):
-	""" Convert phenotypic feature to FHIR Observation. """
-	feature_record = {}
-	feature_record['resourceType'] = 'Observation'
-	if 'id' in obj.keys():
-		feature_record['identifier'] = obj.get('id', None)
-	if 'description' in obj.keys():
-		feature_record['note'] = obj.get('description', None)
-	if 'type' in obj.keys():
-		feature_record['code'] = {}
-		feature_record['code']['coding'] = []
-		ftype = fhir_coding(obj, 'type')
-		feature_record['code']['coding'].append(ftype)
-	if 'onset' in obj.keys():
-		feature_record['onsetAge'] = {}
-		feature_record['onsetAge']['value'] = obj.get('onset').get('label', None)
-		feature_record['onsetAge']['code'] = obj.get('onset').get('id', None)
-	if 'modifier' in obj.keys():
-		feature_record['modifier'] = {}
-		# TODO store all profile references in separate dict, should be treated as a context
-		feature_record['modifier']['url'] = 'http://ga4gh.org/fhir/phenopackets/StructureDefinition/phenotypic-feature-modifier'
-		feature_record['modifier']['coding'] = []
-		for item in obj.get('modifier'):
-			mod = {}
-			mod['code'] = item.get('id')
-			mod['display'] = item.get('label')
-			feature_record['modifier']['coding'].append(mod)
-	if 'evidence' in obj.keys():
-		evidence = obj.get('evidence')
-		feature_record['evidence'] = []
-		evidence_code = {}
-		evidence_code['code'] = []
-		code = {}
-		code['coding'] = []
-		coding = fhir_coding(evidence, 'evidence_code')
-		code['coding'].append(coding)
-		evidence_code['code'].append(code)
-		feature_record['evidence'].append(evidence_code)
-		if 'reference' in evidence.keys():
-			evidence_detail = {}
-			evidence_detail['detail'] = []
-			detail = {}
-			detail['reference'] = evidence.get('reference').get('id')
-			detail['display'] = evidence.get('reference').get('description', None)
-			evidence_detail['detail'].append(detail)
-			feature_record['evidence'].append(evidence_detail)
-	return feature_record
-
-
 def fhir_specimen(obj):
+	""" Converts biosample to FHIR Specimen. """
+
 	specimen = s.Specimen()
 	specimen.identifier = []
 	# id
@@ -332,43 +262,6 @@ def fhir_codeable_concept(obj):
 		coding = fhir_coding_util(obj)
 		codeable_concept.coding.append(coding)
 	return codeable_concept
-
-
-def biosample_to_fhir(obj):
-	""" Convert biosample to FHIR Specimen. """
-
-	biosample_record = {}
-	biosample_record['resourceType'] = 'Specimen'
-	biosample_record['identifier'] = obj.get('id', None)
-	biosample_record['parent'] = {}
-	biosample_record['parent']['reference'] = {}
-	biosample_record['parent']['reference']['reference'] = obj.get('sampled_tissue').get('id', None)
-	biosample_record['parent']['reference']['display'] = obj.get('sampled_tissue').get('label', None)
-	# mapping for phenotypic_features related to each biosample
-	if 'phenotypic_features' in obj.keys():
-		biosample_record['phenotypicFeatures'] = []
-		for feature in obj.get('phenotypic_features'):
-			feature_record = phenotypic_feature_to_fhir(feature)
-			biosample_record['phenotypicFeatures'].append(feature_record)
-	# mapping for procedure related to each biosample
-	if 'procedure' in obj.keys():
-		procedure = obj.get('procedure')
-		biosample_record['collection'] = {}
-		biosample_record['collection']['method'] = procedure_to_fhir(procedure).get('code')
-		biosample_record['collection']['bodySite'] = procedure_to_fhir(procedure).get('bodySite')
-	# all these elements are represented by FHIR Class CodeableConcept
-	# and have the same schema
-	codeable_concepts = [
-		'taxonomy', 'histological_diagnosis',
-		'tumor_progression', 'tumor_grade',
-		'diagnostic_markers'
-		]
-	for concept in codeable_concepts:
-		if concept in obj.keys():
-			concept_data = obj.get(concept)
-			concept_field_name = camel_case_field_names(concept)
-			biosample_record[concept_field_name] = fhir_codeable_concept(concept_data)
-	return biosample_record
 
 
 def hts_file_to_fhir(obj):

--- a/chord_metadata_service/restapi/fhir_utils.py
+++ b/chord_metadata_service/restapi/fhir_utils.py
@@ -95,10 +95,11 @@ def procedure_to_fhir(obj):
 	procedure['code']['coding'] = []
 	coding = fhir_coding(obj, 'code')
 	procedure['code']['coding'].append(coding)
-	procedure['bodySite'] = {}
-	procedure['bodySite']['coding'] = []
-	body_site_coding = fhir_coding(obj, 'body_site')
-	procedure['bodySite']['coding'].append(body_site_coding)
+	if obj.get('body_site'):
+		procedure['bodySite'] = {}
+		procedure['bodySite']['coding'] = []
+		body_site_coding = fhir_coding(obj, 'body_site')
+		procedure['bodySite']['coding'].append(body_site_coding)
 	return procedure
 
 

--- a/chord_metadata_service/restapi/fhir_utils.py
+++ b/chord_metadata_service/restapi/fhir_utils.py
@@ -181,7 +181,8 @@ def fhir_specimen(obj):
 	# individual_age_at_collection
 	if 'individual_age_at_collection' in obj.keys():
 		ind_age_at_collection_extension = extension.Extension()
-		ind_age_at_collection_extension.url = PHENOPACKETS_ON_FHIR_MAPPING['biosample']['individual_age_at_collection']
+		ind_age_at_collection_extension.url = PHENOPACKETS_ON_FHIR_MAPPING['biosample']\
+			['individual_age_at_collection']
 		if isinstance(obj['individual_age_at_collection']['age'], dict):
 			ind_age_at_collection_extension.valueRange = range.Range()
 			ind_age_at_collection_extension.valueRange.low = quantity.Quantity()

--- a/chord_metadata_service/restapi/fhir_utils.py
+++ b/chord_metadata_service/restapi/fhir_utils.py
@@ -166,7 +166,30 @@ def fhir_observation(obj):
 	concept_extensions = codeable_concepts_fields(['severity', 'modifier', 'onset'], obj)
 	for c in concept_extensions:
 		observation.extension.append(c)
-
+	if 'evidence' in obj.keys():
+		evidence = extension.Extension()
+		evidence.url = GA4GH_FHIR_PROFILES['evidence']
+		evidence.extension = []
+		evidence_code = extension.Extension()
+		evidence_code.url = GA4GH_FHIR_PROFILES['evidence_code']
+		evidence_code.valueCodeableConcept = fhir_codeable_concept(obj['evidence']['evidence_code'])
+		evidence.extension.append(evidence_code)
+		if 'reference' in obj['evidence'].keys():
+			evidence_reference = extension.Extension()
+			evidence_reference.url = GA4GH_FHIR_PROFILES['reference']
+			evidence_reference.extension = []
+			evidence_reference_id = extension.Extension()
+			evidence_reference_id.url = GA4GH_FHIR_PROFILES['extension_id_url']
+			# GA$GH guide requires valueURL but there is no such property
+			evidence_reference_id.valueUri = obj['evidence']['reference']['id']
+			evidence_reference.extension.append(evidence_reference_id)
+			if 'description' in obj['evidence']['reference'].keys():
+				evidence_reference_desc = extension.Extension()
+				evidence_reference_desc.url = GA4GH_FHIR_PROFILES['extension_description_url']
+				evidence_reference_desc.valueString = obj['evidence']['reference'].get('description', None)
+				evidence_reference.extension.append(evidence_reference_desc)
+			evidence.extension.append(evidence_reference)
+		observation.extension.append(evidence)
 	return observation.as_json()
 
 

--- a/chord_metadata_service/restapi/fhir_utils.py
+++ b/chord_metadata_service/restapi/fhir_utils.py
@@ -265,19 +265,6 @@ def fhir_document_reference(obj):
 	return doc_ref.as_json()
 
 
-def gene_to_fhir(obj):
-	""" Gene to FHIR CodeableConcept. """
-
-	gene_record = {}
-	gene_record['resourceType'] = 'CodeableConcept'
-	gene_record['coding'] = []
-	coding = {}
-	coding['code'] = obj.get('id', None)
-	coding['display'] = obj.get('symbol', None)
-	gene_record['coding'].append(coding)
-	return gene_record
-
-
 def fhir_obs_component_region_studied(obj):
 	""" Gene corresponds to Observation.component."""
 

--- a/chord_metadata_service/restapi/fhir_utils.py
+++ b/chord_metadata_service/restapi/fhir_utils.py
@@ -1,5 +1,6 @@
 from datetime import datetime
-from chord_metadata_service.restapi.ga4gh_fhir_profiles import HL7_GENOMICS_REPORTING, PHENOPACKETS_ON_FHIR_MAPPING
+from chord_metadata_service.restapi.phenopackets_on_fhir_mapping import PHENOPACKETS_ON_FHIR_MAPPING
+from chord_metadata_service.restapi.hl7_genomics_mapping import HL7_GENOMICS_MAPPING
 from fhirclient.models import (observation as obs, patient as p, extension, age, coding as c,
 							codeableconcept, specimen as s, identifier as fhir_indentifier,
 							annotation as a, range, quantity, fhirreference,
@@ -265,11 +266,11 @@ def fhir_obs_component_region_studied(obj):
 	# http://hl7.org/fhir/uv/genomics-reporting/StructureDefinition/region-studied
 
 	component = obs.ObservationComponent()
-	component.code = fhir_codeable_concept(HL7_GENOMICS_REPORTING['observation_component_gene_studied'])
+	component.code = fhir_codeable_concept(HL7_GENOMICS_MAPPING['gene']['gene_studied_code'])
 	component.valueCodeableConcept = fhir_codeable_concept({
 			"id": obj['id'],
 			"label": obj['symbol'],
-			"system": HL7_GENOMICS_REPORTING['HGNC']
+			"system": HL7_GENOMICS_MAPPING['gene']['gene_studied_value']['system']
 		})
 	return component.as_json()
 
@@ -278,7 +279,7 @@ def fhir_obs_component_variant(obj):
 	""" Variant corresponds to Observation.component:variant """
 
 	component = obs.ObservationComponent()
-	component.code = fhir_codeable_concept(HL7_GENOMICS_REPORTING['observation_component_variant'])
+	component.code = fhir_codeable_concept(HL7_GENOMICS_MAPPING['variant']['variant_length_code'])
 	component.valueCodeableConcept = fhir_codeable_concept(
 		{"id": obj.get('allele_type'), "label": obj.get('allele_type')}
 	)

--- a/chord_metadata_service/restapi/fhir_utils.py
+++ b/chord_metadata_service/restapi/fhir_utils.py
@@ -63,23 +63,16 @@ def fhir_coding(obj, value=None):
 	return coding
 
 
-def procedure_to_fhir(obj):
-	""" Convert procedure to FHIR Procedure. """
+def fhir_specimen_collection(obj):
+	""" Converts Procedure to FHIR Specimen collection. """
 
-	procedure = {}
-	procedure['resourceType'] = 'Procedure'
-	if 'id' in obj.keys():
-		procedure['identifier'] = obj.get('id', None)
-	procedure['code'] = {}
-	procedure['code']['coding'] = []
-	coding = fhir_coding(obj, 'code')
-	procedure['code']['coding'].append(coding)
-	if obj.get('body_site'):
-		procedure['bodySite'] = {}
-		procedure['bodySite']['coding'] = []
-		body_site_coding = fhir_coding(obj, 'body_site')
-		procedure['bodySite']['coding'].append(body_site_coding)
-	return procedure
+	collection = s.SpecimenCollection()
+	collection.id = str(obj['id'])
+	collection.method = fhir_codeable_concept(obj['code'])
+	if 'body_site' in obj.keys():
+		collection.bodySite = fhir_codeable_concept(obj['body_site'])
+	return collection.as_json()
+
 
 def codeable_concepts_fields(field_list, obj):
 	concept_extensions = []

--- a/chord_metadata_service/restapi/fhir_utils.py
+++ b/chord_metadata_service/restapi/fhir_utils.py
@@ -278,25 +278,20 @@ def gene_to_fhir(obj):
 	return gene_record
 
 
-def fhir_obs_region_studied(obj):
+def fhir_obs_component_region_studied(obj):
 	""" Gene corresponds to Observation.component."""
-	# GA4GH to FHIR Mapping Guide provides link to
+
+	# GA4GH to FHIR Mapping Guide provides a link to
 	# Genomics Reporting Implementation Guide (STU1) mapping
-	# Genomics Reporting Implementation Guide (STU1)
-	# http://build.fhir.org/ig/HL7/genomics-reporting/region-studied.html
-	component = backboneelement.BackboneElement()
-	component.modifierExtension = []
-	comp_extention = extension.Extension()
-	comp_extention.valueCodeableConcept = fhir_codeable_concept({
-		"id": obj['id'],
-		"label": obj['symbol'],
-		"system": HL7_GENOMICS_REPORTING['HGNC']
-	})
-	# comp_extention.code = fhir_codeable_concept(
-	# 	HL7_GENOMICS_REPORTING['gene_studied']
-	# )
-	comp_extention.url = GA4GH_FHIR_PROFILES['region_studied']
-	component.modifierExtension.append(comp_extention)
+	# http://hl7.org/fhir/uv/genomics-reporting/StructureDefinition/region-studied
+
+	component = obs.ObservationComponent()
+	component.code = fhir_codeable_concept(HL7_GENOMICS_REPORTING['observation_component_gene_studied'])
+	component.valueCodeableConcept = fhir_codeable_concept({
+			"id": obj['id'],
+			"label": obj['symbol'],
+			"system": HL7_GENOMICS_REPORTING['HGNC']
+		})
 	return component.as_json()
 
 

--- a/chord_metadata_service/restapi/fhir_utils.py
+++ b/chord_metadata_service/restapi/fhir_utils.py
@@ -190,6 +190,10 @@ def fhir_observation(obj):
 				evidence_reference.extension.append(evidence_reference_desc)
 			evidence.extension.append(evidence_reference)
 		observation.extension.append(evidence)
+
+	if 'biosample' in obj.keys():
+		observation.specimen = fhirreference.FHIRReference()
+		observation.specimen.reference = obj.get('biosample', None)
 	return observation.as_json()
 
 

--- a/chord_metadata_service/restapi/fhir_utils.py
+++ b/chord_metadata_service/restapi/fhir_utils.py
@@ -316,13 +316,13 @@ def fhir_condition(obj):
 	condition.subject = fhirreference.FHIRReference()
 	condition.subject.reference = 'unknown'
 	condition.extension = []
-	onset_extension = extension.Extension()
-	onset_extension.url = PHENOPACKETS_ON_FHIR_MAPPING['disease']['onset']
 	# only adds disease-onset if it's ontology term
 	# NOTE it is required element by Pheno-FHIR mapping guide but not Phenopackets
 	if check_disease_onset(obj):
+		onset_extension = extension.Extension()
+		onset_extension.url = PHENOPACKETS_ON_FHIR_MAPPING['disease']['onset']
 		onset_extension.valueCodeableConcept = fhir_codeable_concept(obj['onset']['age'])
-	condition.extension.append(onset_extension)
+		condition.extension.append(onset_extension)
 
 	if 'disease_stage' in obj.keys():
 		for item in obj['disease_stage']:

--- a/chord_metadata_service/restapi/fhir_utils.py
+++ b/chord_metadata_service/restapi/fhir_utils.py
@@ -23,11 +23,22 @@ def fhir_patient(obj):
 	patient.deceasedBoolean = obj.get('deceased', None)
 	patient.extension = list()
 	# age
-	age_extension = extension.Extension()
-	age_extension.url = PHENOPACKETS_ON_FHIR_MAPPING['individual']['age']
-	age_extension.valueAge = age.Age()
-	age_extension.valueAge.unit = obj.get('age', None).get('age', None)
-	patient.extension.append(age_extension)
+	# TODO add separate func for age
+	if 'age' in obj.keys():
+		age_extension = extension.Extension()
+		age_extension.url = PHENOPACKETS_ON_FHIR_MAPPING['individual']['age']
+		if isinstance(obj['age']['age'], dict):
+			age_extension.valueRange = range.Range()
+			age_extension.valueRange.low = quantity.Quantity()
+			# TOD check this nesting
+			age_extension.valueRange.low.unit = obj['age']['age']['start']['age']
+			age_extension.valueRange.high = quantity.Quantity()
+			age_extension.valueRange.high.unit = obj['age']['age']['end']['age']
+			patient.extension.append(age_extension)
+		else:
+			age_extension.valueAge = age.Age()
+			age_extension.valueAge.unit = obj['age']['age']
+			patient.extension.append(age_extension)
 	# karyotypic_sex
 	karyotypic_sex_extension = extension.Extension()
 	karyotypic_sex_extension.url = PHENOPACKETS_ON_FHIR_MAPPING['individual']['karyotypic_sex']['url']
@@ -179,6 +190,7 @@ def fhir_specimen(obj):
 	# extensions
 	specimen.extension = []
 	# individual_age_at_collection
+	# TODO add separate func for age
 	if 'individual_age_at_collection' in obj.keys():
 		ind_age_at_collection_extension = extension.Extension()
 		ind_age_at_collection_extension.url = PHENOPACKETS_ON_FHIR_MAPPING['biosample']\

--- a/chord_metadata_service/restapi/fhir_utils.py
+++ b/chord_metadata_service/restapi/fhir_utils.py
@@ -34,7 +34,7 @@ def fhir_patient(obj):
 	""" Converts Individual to FHIR Patient. """
 
 	patient = p.Patient()
-	patient.id = obj.get('id', None)
+	patient.id = obj['id']
 	patient.birthDate = fhirdate.FHIRDate(obj.get('date_of_birth', None))
 	patient.gender = obj.get('sex', None)
 	patient.active = obj.get('active', None)
@@ -56,15 +56,16 @@ def fhir_patient(obj):
 	karyotypic_sex_extension.valueCodeableConcept.coding.append(coding)
 	patient.extension.append(karyotypic_sex_extension)
 	# taxonomy
-	taxonomy_extension = extension.Extension()
-	taxonomy_extension.url = PHENOPACKETS_ON_FHIR_MAPPING['individual']['taxonomy']
-	taxonomy_extension.valueCodeableConcept = codeableconcept.CodeableConcept()
-	taxonomy_extension.valueCodeableConcept.coding = list()
-	coding = c.Coding()
-	coding.display = obj.get('taxonomy', None).get('label', None)
-	coding.code = obj.get('taxonomy', None).get('id', None)
-	taxonomy_extension.valueCodeableConcept.coding.append(coding)
-	patient.extension.append(taxonomy_extension)
+	if 'taxonomy' in obj.keys():
+		taxonomy_extension = extension.Extension()
+		taxonomy_extension.url = PHENOPACKETS_ON_FHIR_MAPPING['individual']['taxonomy']
+		taxonomy_extension.valueCodeableConcept = codeableconcept.CodeableConcept()
+		taxonomy_extension.valueCodeableConcept.coding = list()
+		coding = c.Coding()
+		coding.display = obj.get('taxonomy', None).get('label', None)
+		coding.code = obj.get('taxonomy', None).get('id', None)
+		taxonomy_extension.valueCodeableConcept.coding.append(coding)
+		patient.extension.append(taxonomy_extension)
 	return patient.as_json()
 
 

--- a/chord_metadata_service/restapi/fhir_utils.py
+++ b/chord_metadata_service/restapi/fhir_utils.py
@@ -245,6 +245,11 @@ def fhir_specimen(obj):
 			codeable_concepts_extension.url = GA4GH_FHIR_PROFILES[field]
 			codeable_concepts_extension.valueCodeableConcept = fhir_codeable_concept(obj[field])
 			specimen.extension.append(codeable_concepts_extension)
+	if 'is_control_sample' in obj.keys():
+		control_extension = extension.Extension()
+		control_extension.url = GA4GH_FHIR_PROFILES['is_control_sample']
+		control_extension.valueBoolean = obj['is_control_sample']
+		specimen.extension.append(control_extension)
 	# TODO 2m extensions - references
 	return specimen.as_json()
 

--- a/chord_metadata_service/restapi/fhir_utils.py
+++ b/chord_metadata_service/restapi/fhir_utils.py
@@ -183,7 +183,7 @@ def phenotypic_feature_to_fhir(obj):
 
 from fhirclient.models import (specimen as s, identifier as fhir_indentifier,
 							   fhirreference, annotation as a,
-							   range, quantity)
+							   range, quantity, fhirreference, )
 
 
 def fhir_specimen(obj):
@@ -209,6 +209,11 @@ def fhir_specimen(obj):
 		annotation = a.Annotation()
 		annotation.text = obj.get('description', None)
 		specimen.note.append(annotation)
+	# procedure
+	specimen.collection = s.SpecimenCollection()
+	specimen.collection.method = fhir_codeable_concept(obj['procedure']['code'])
+	if 'body_site' in obj['procedure'].keys():
+		specimen.collection.bodySite = fhir_codeable_concept(obj['procedure']['body_site'])
 	# Note on taxonomy from phenopackets specs:
 	# Individuals already contain a taxonomy attribute so this attribute is not needed.
 	# extensions
@@ -240,7 +245,7 @@ def fhir_specimen(obj):
 			codeable_concepts_extension.url = GA4GH_FHIR_PROFILES[field]
 			codeable_concepts_extension.valueCodeableConcept = fhir_codeable_concept(obj[field])
 			specimen.extension.append(codeable_concepts_extension)
-
+	# TODO 2m extensions - references
 	return specimen.as_json()
 
 

--- a/chord_metadata_service/restapi/fhir_utils.py
+++ b/chord_metadata_service/restapi/fhir_utils.py
@@ -168,7 +168,7 @@ def fhir_specimen(obj):
 	specimen.identifier = []
 	# id
 	identifier = fhir_indentifier.Identifier()
-	identifier.value = obj.get('id', None)
+	identifier.value = obj['id']
 	specimen.identifier.append(identifier)
 	# individual - subject property in FHIR is mandatory for a specimen
 	specimen.subject = fhirreference.FHIRReference()
@@ -177,8 +177,8 @@ def fhir_specimen(obj):
 	specimen.type = codeableconcept.CodeableConcept()
 	specimen.type.coding = []
 	coding = c.Coding()
-	coding.code = obj.get('sampled_tissue', None).get('id', None)
-	coding.display = obj.get('sampled_tissue', None).get('label', None)
+	coding.code = obj['sampled_tissue']['id']
+	coding.display = obj['sampled_tissue']['label']
 	specimen.type.coding.append(coding)
 	# description
 	if 'description' in obj.keys():

--- a/chord_metadata_service/restapi/fhir_utils.py
+++ b/chord_metadata_service/restapi/fhir_utils.py
@@ -8,33 +8,6 @@ from fhirclient.models import (observation as obs, patient as p, extension, age,
 
 # Utils for converting data between formats
 
-# TODO move to a separate file
-def camel_case_field_names(string):
-	""" Function to convert snake_case field names to camelCase """
-
-	if '_' in string:
-		splitted = string.split('_')
-		capitilized = []
-		capitilized.append(splitted[0])
-		for each in splitted[1:]:
-			capitilized.append(each.title())
-		return ''.join(capitilized)
-	return string
-
-
-def transform_keys(obj):
-	"""
-	This function is needed for validation against DATS schemas that use camelCase.
-	Iterates over a dict and  changes all keys in nested objects to cameCase.
-	"""
-	if isinstance(obj, dict):
-		transformed_obj = {}
-		for key, value in obj.items():
-			if isinstance(value, dict):
-				value = transform_keys(value)
-			transformed_obj[camel_case_field_names(key)] = value
-		return transformed_obj
-
 
 def fhir_patient(obj):
 	""" Converts Individual to FHIR Patient. """
@@ -48,7 +21,6 @@ def fhir_patient(obj):
 	patient.extension = list()
 	# age
 	age_extension = extension.Extension()
-	# TODO move phenopackets-fhir mappings in a separate file
 	age_extension.url = GA4GH_FHIR_PROFILES['individual-age']
 	age_extension.valueAge = age.Age()
 	age_extension.valueAge.unit = obj.get('age', None).get('age', None)

--- a/chord_metadata_service/restapi/fhir_utils.py
+++ b/chord_metadata_service/restapi/fhir_utils.py
@@ -277,7 +277,7 @@ def gene_to_fhir(obj):
 	gene_record['coding'].append(coding)
 	return gene_record
 
-import json
+
 def fhir_obs_region_studied(obj):
 	""" Gene corresponds to Observation.component."""
 	# GA4GH to FHIR Mapping Guide provides link to
@@ -300,20 +300,15 @@ def fhir_obs_region_studied(obj):
 	return component.as_json()
 
 
-def variant_to_fhir(obj):
-	""" Variant to FHIR """
-	# TODO check this example
-	# http://build.fhir.org/ig/HL7/genomics-reporting/SNVexample.json.html
+def fhir_obs_component_variant(obj):
+	""" Variant corresponds to Observation.component:variant """
 
-	variant_record = {}
-	variant_record['resourceType'] = 'Observation'
-	variant_record['identifier'] = obj.get('id', None)
-	variant_record['meta'] = {}
-	variant_record['meta']['profile'] = [
-		'http://hl7.org/fhir/uv/genomics-reporting/StructureDefinition/variant'
-		]
-
-	return variant_record
+	component = obs.ObservationComponent()
+	component.code = fhir_codeable_concept(HL7_GENOMICS_REPORTING['observation_component_variant'])
+	component.valueCodeableConcept = fhir_codeable_concept(
+		{"id": obj.get('allele_type'), "label": obj.get('allele_type')}
+	)
+	return component.as_json()
 
 
 def disease_to_fhir(obj):

--- a/chord_metadata_service/restapi/fhir_utils.py
+++ b/chord_metadata_service/restapi/fhir_utils.py
@@ -69,19 +69,6 @@ def fhir_patient(obj):
 	return patient.as_json()
 
 
-def fhir_coding(obj, value=None):
-	""" Generic function to convert to FHIR coding element. """
-
-	coding = {}
-	if value:
-		coding['code'] = obj.get(value).get('id', None)
-		coding['display'] = obj.get(value).get('label', None)
-	else:
-		coding['code'] = obj.get('id', None)
-		coding['display'] = obj.get('label', None)
-	return coding
-
-
 def fhir_specimen_collection(obj):
 	""" Converts Procedure to FHIR Specimen collection. """
 

--- a/chord_metadata_service/restapi/ga4gh_fhir_profiles.py
+++ b/chord_metadata_service/restapi/ga4gh_fhir_profiles.py
@@ -22,6 +22,18 @@ GA4GH_FHIR_PROFILES = {
     "extension_description_url": "description",
     "document_reference_status": "current",
     "hts_file": "http://ga4gh.org/fhir/phenopackets/StructureDefinition/HtsFile",
-    "genome_assembly": "http://ga4gh.org/fhir/phenopackets/StructureDefinition/htsfile-genome-assembly"
+    "genome_assembly": "http://ga4gh.org/fhir/phenopackets/StructureDefinition/htsfile-genome-assembly",
+    # FHIR
+    "region_studied": "http://hl7.org/fhir/uv/genomics-reporting/StructureDefinition/region-studied"
 
+}
+
+
+HL7_GENOMICS_REPORTING = {
+    "gene_studied": {
+        "system": "https://loinc.org",
+        "id": "48018-6",
+        "label": "Gene studied [ID]"
+    },
+    "HGNC": "https://www.genenames.org/"
 }

--- a/chord_metadata_service/restapi/ga4gh_fhir_profiles.py
+++ b/chord_metadata_service/restapi/ga4gh_fhir_profiles.py
@@ -1,0 +1,11 @@
+GA4GH_FHIR_PROFILES = {
+    "individual-age": "http://ga4gh.org/fhir/phenopackets/StructureDefinition/individual-age",
+    "individual-karyotypic-sex": {
+        "url": "http://ga4gh.org/fhir/phenopackets/StructureDefinition/individual-karyotypic-sex",
+        "coding_system": "http://ga4gh.org/fhir/phenopackets/CodeSystem/karyotypic-sex"
+    }
+
+        ,
+    "individual-taxonomy": "http://ga4gh.org/fhir/phenopackets/StructureDefinition/individual-taxonomy",
+    "individual_age_at_collection": "http://ga4gh.org/fhir/phenopackets/StructureDefinition/biosample-individual-age-at-collection"
+}

--- a/chord_metadata_service/restapi/ga4gh_fhir_profiles.py
+++ b/chord_metadata_service/restapi/ga4gh_fhir_profiles.py
@@ -30,7 +30,7 @@ GA4GH_FHIR_PROFILES = {
 
 
 HL7_GENOMICS_REPORTING = {
-    "gene_studied": {
+    "observation_component_gene_studied": {
         "system": "https://loinc.org",
         "id": "48018-6",
         "label": "Gene studied [ID]"

--- a/chord_metadata_service/restapi/ga4gh_fhir_profiles.py
+++ b/chord_metadata_service/restapi/ga4gh_fhir_profiles.py
@@ -1,5 +1,55 @@
-# Allf fixed values provided by Pheno_FHIR Mapping guide
+# All fixed values provided by Pheno_FHIR Mapping guide
 # TODO split by some logic
+PHENOPACKETS_ON_FHIR_MAPPING = {
+    "individual": {
+        "title": "Individual",
+        "url": "http://ga4gh.org/fhir/phenopackets/StructureDefinition/Individual",
+        "age": "http://ga4gh.org/fhir/phenopackets/StructureDefinition/individual-age",
+        "karyotypic_sex": {
+            "url": "http://ga4gh.org/fhir/phenopackets/StructureDefinition/individual-karyotypic-sex",
+            "system": "http://ga4gh.org/fhir/phenopackets/CodeSystem/karyotypic-sex"
+        },
+        "taxonomy": "http://ga4gh.org/fhir/phenopackets/StructureDefinition/individual-taxonomy"
+    },
+    "phenopacket": {
+        "title": "Phenopacket",
+        "code": {
+            "system": "http://ga4gh.org/fhir/phenopackets/CodeSystem/document-type",
+            "code": "phenopacket"
+        },
+        "url": "http://ga4gh.org/fhir/phenopackets/StructureDefinition/Phenopacket"
+    },
+    "biosample": {
+        "title": "Biosample",
+        "url": "http://ga4gh.org/fhir/phenopackets/StructureDefinition/Biosample",
+        "individual_age_at_collection": "http://ga4gh.org/fhir/phenopackets/StructureDefinition/biosample-individual-age-at-collection",
+        "histological_diagnosis": "http://ga4gh.org/fhir/phenopackets/StructureDefinition/biosample-histological-diagnosis",
+        "tumor_progression": "http://ga4gh.org/fhir/phenopackets/StructureDefinition/biosample-tumor-progression",
+        "tumor_grade": "http://ga4gh.org/fhir/phenopackets/StructureDefinition/biosample-tumor-grade",
+        "diagnostic_markers": "http://ga4gh.org/fhir/phenopackets/StructureDefinition/biosample-diagnostic-markers",
+        "is_control_sample": "http://ga4gh.org/fhir/phenopackets/StructureDefinition/biosample-control"
+    },
+    "phenotypic_feature": {
+        "title": "Phenotypic Feature",
+        "url": "http://ga4gh.org/fhir/phenopackets/StructureDefinition/PhenotypicFeature",
+        "severity": "http://ga4gh.org/fhir/phenopackets/StructureDefinition/phenotypic-feature-severity",
+        "modifier": "http://ga4gh.org/fhir/phenopackets/StructureDefinition/phenotypic-feature-modifier",
+        "onset": "http://ga4gh.org/fhir/phenopackets/StructureDefinition/phenotypic-feature-onset",
+        "evidence": {
+            "url": "http://ga4gh.org/fhir/phenopackets/StructureDefinition/evidence",
+            # fixed value
+            "evidence_code": "evidenceCode"
+
+        }
+
+
+    }
+    
+
+
+}
+
+
 GA4GH_FHIR_PROFILES = {
     "individual-age": "http://ga4gh.org/fhir/phenopackets/StructureDefinition/individual-age",
     "individual-karyotypic-sex": {

--- a/chord_metadata_service/restapi/ga4gh_fhir_profiles.py
+++ b/chord_metadata_service/restapi/ga4gh_fhir_profiles.py
@@ -17,7 +17,52 @@ PHENOPACKETS_ON_FHIR_MAPPING = {
             "system": "http://ga4gh.org/fhir/phenopackets/CodeSystem/document-type",
             "code": "phenopacket"
         },
-        "url": "http://ga4gh.org/fhir/phenopackets/StructureDefinition/Phenopacket"
+        "url": "http://ga4gh.org/fhir/phenopackets/StructureDefinition/Phenopacket",
+        "phenotypic_features": {
+            "title": "Phenotypic Features",
+            "code": {
+                "system": "http://ga4gh.org/fhir/phenopackets/CodeSystem/section-type",
+                "version": "0.1.0",
+                "code": "phenotypic-features",
+                "display": "Phenotypic Features"
+            }
+        },
+        "biosamples": {
+                "title": "Biosamples",
+                "code": {
+                    "system": "http://ga4gh.org/fhir/phenopackets/CodeSystem/section-type",
+                    "version": "0.1.0",
+                    "code": "biosamples",
+                    "display": "Biosamples"
+                }
+            },
+        "variants": {
+            "title": "Variants",
+            "code": {
+                "system": "http://ga4gh.org/fhir/phenopackets/CodeSystem/section-type",
+                "version": "0.1.0",
+                "code": "variants",
+                "display": "Variants"
+            }
+        },
+        "diseases": {
+            "title": "Diseases",
+            "code": {
+                "system": "http://ga4gh.org/fhir/phenopackets/CodeSystem/section-type",
+                "version": "0.1.0",
+                "code": "diseases",
+                "display": "Diseases"
+            }
+        },
+        "hts_files": {
+            "title": "HTS Files",
+            "code": {
+                "system": "http://ga4gh.org/fhir/phenopackets/CodeSystem/section-type",
+                "version": "0.1.0",
+                "code": "hts-files",
+                "display": "HTS Files"
+            }
+        }
     },
     "biosample": {
         "title": "Biosample",
@@ -39,14 +84,26 @@ PHENOPACKETS_ON_FHIR_MAPPING = {
             "url": "http://ga4gh.org/fhir/phenopackets/StructureDefinition/evidence",
             # fixed value
             "evidence_code": "evidenceCode"
-
         }
-
-
+    },
+    "external_reference": {
+        "url": "http://ga4gh.org/fhir/phenopackets/StructureDefinition/external-reference",
+        # fixed values
+        "id_url": "id",
+        "description_url": "description"
+    },
+    "hts_file": {
+        "url": "http://ga4gh.org/fhir/phenopackets/StructureDefinition/HtsFile",
+        "genome_assembly": "http://ga4gh.org/fhir/phenopackets/StructureDefinition/htsfile-genome-assembly",
+        # fixed value
+        "status": "current",
+        "hts_format": "http://ga4gh.org/fhir/phenopackets/CodeSystem/hts-format"
+    },
+    "disease": {
+        "url": "http://ga4gh.org/fhir/phenopackets/StructureDefinition/Disease",
+        "onset": "http://ga4gh.org/fhir/phenopackets/StructureDefinition/disease-onset",
+        "disease_stage": "http://ga4gh.org/fhir/phenopackets/StructureDefinition/disease-tumor-stage",
     }
-    
-
-
 }
 
 

--- a/chord_metadata_service/restapi/ga4gh_fhir_profiles.py
+++ b/chord_metadata_service/restapi/ga4gh_fhir_profiles.py
@@ -3,15 +3,15 @@ GA4GH_FHIR_PROFILES = {
     "individual-karyotypic-sex": {
         "url": "http://ga4gh.org/fhir/phenopackets/StructureDefinition/individual-karyotypic-sex",
         "coding_system": "http://ga4gh.org/fhir/phenopackets/CodeSystem/karyotypic-sex"
-    }
-
-        ,
+    },
     "individual-taxonomy": "http://ga4gh.org/fhir/phenopackets/StructureDefinition/individual-taxonomy",
     "biosample-individual-age-at-collection": "http://ga4gh.org/fhir/phenopackets/StructureDefinition/biosample-individual-age-at-collection",
     "histological_diagnosis": "http://ga4gh.org/fhir/phenopackets/StructureDefinition/biosample-histological-diagnosis",
     "tumor_progression": "http://ga4gh.org/fhir/phenopackets/StructureDefinition/biosample-tumor-progression",
     "tumor_grade": "http://ga4gh.org/fhir/phenopackets/StructureDefinition/biosample-tumor-grade",
     "diagnostic_markers": "http://ga4gh.org/fhir/phenopackets/StructureDefinition/biosample-diagnostic-markers",
-    "is_control_sample": "http://ga4gh.org/fhir/phenopackets/StructureDefinition/biosample-control"
-
+    "is_control_sample": "http://ga4gh.org/fhir/phenopackets/StructureDefinition/biosample-control",
+    "severity": "http://ga4gh.org/fhir/phenopackets/StructureDefinition/phenotypic-feature-severity",
+    "modifier": "http://ga4gh.org/fhir/phenopackets/StructureDefinition/phenotypic-feature-modifier",
+    "onset": "http://ga4gh.org/fhir/phenopackets/StructureDefinition/phenotypic-feature-onset"
 }

--- a/chord_metadata_service/restapi/ga4gh_fhir_profiles.py
+++ b/chord_metadata_service/restapi/ga4gh_fhir_profiles.py
@@ -11,6 +11,7 @@ GA4GH_FHIR_PROFILES = {
     "histological_diagnosis": "http://ga4gh.org/fhir/phenopackets/StructureDefinition/biosample-histological-diagnosis",
     "tumor_progression": "http://ga4gh.org/fhir/phenopackets/StructureDefinition/biosample-tumor-progression",
     "tumor_grade": "http://ga4gh.org/fhir/phenopackets/StructureDefinition/biosample-tumor-grade",
-    "diagnostic_markers": "http://ga4gh.org/fhir/phenopackets/StructureDefinition/biosample-diagnostic-markers"
+    "diagnostic_markers": "http://ga4gh.org/fhir/phenopackets/StructureDefinition/biosample-diagnostic-markers",
+    "is_control_sample": "http://ga4gh.org/fhir/phenopackets/StructureDefinition/biosample-control"
 
 }

--- a/chord_metadata_service/restapi/ga4gh_fhir_profiles.py
+++ b/chord_metadata_service/restapi/ga4gh_fhir_profiles.py
@@ -13,5 +13,11 @@ GA4GH_FHIR_PROFILES = {
     "is_control_sample": "http://ga4gh.org/fhir/phenopackets/StructureDefinition/biosample-control",
     "severity": "http://ga4gh.org/fhir/phenopackets/StructureDefinition/phenotypic-feature-severity",
     "modifier": "http://ga4gh.org/fhir/phenopackets/StructureDefinition/phenotypic-feature-modifier",
-    "onset": "http://ga4gh.org/fhir/phenopackets/StructureDefinition/phenotypic-feature-onset"
+    "onset": "http://ga4gh.org/fhir/phenopackets/StructureDefinition/phenotypic-feature-onset",
+    "evidence": "http://ga4gh.org/fhir/phenopackets/StructureDefinition/evidence",
+    "reference": "http://ga4gh.org/fhir/phenopackets/StructureDefinition/external-reference",
+    # GA4GH guide provides hardcoded values
+    "evidence_code": "evidenceCode",
+    "extension_id_url": "id",
+    "extension_description_url": "description"
 }

--- a/chord_metadata_service/restapi/ga4gh_fhir_profiles.py
+++ b/chord_metadata_service/restapi/ga4gh_fhir_profiles.py
@@ -35,5 +35,11 @@ HL7_GENOMICS_REPORTING = {
         "id": "48018-6",
         "label": "Gene studied [ID]"
     },
-    "HGNC": "https://www.genenames.org/"
+    "HGNC": "https://www.genenames.org/",
+    "variant": "http://hl7.org/fhir/uv/genomics-reporting/StructureDefinition/variant",
+    "observation_component_variant": {
+        "system": "https://loinc.org",
+        "id": "81300-6",
+        "label": "Structural variant [Length]"
+    }
 }

--- a/chord_metadata_service/restapi/ga4gh_fhir_profiles.py
+++ b/chord_metadata_service/restapi/ga4gh_fhir_profiles.py
@@ -19,5 +19,9 @@ GA4GH_FHIR_PROFILES = {
     # GA4GH guide provides hardcoded values
     "evidence_code": "evidenceCode",
     "extension_id_url": "id",
-    "extension_description_url": "description"
+    "extension_description_url": "description",
+    "document_reference_status": "current",
+    "hts_file": "http://ga4gh.org/fhir/phenopackets/StructureDefinition/HtsFile",
+    "genome_assembly": "http://ga4gh.org/fhir/phenopackets/StructureDefinition/htsfile-genome-assembly"
+
 }

--- a/chord_metadata_service/restapi/ga4gh_fhir_profiles.py
+++ b/chord_metadata_service/restapi/ga4gh_fhir_profiles.py
@@ -7,5 +7,10 @@ GA4GH_FHIR_PROFILES = {
 
         ,
     "individual-taxonomy": "http://ga4gh.org/fhir/phenopackets/StructureDefinition/individual-taxonomy",
-    "individual_age_at_collection": "http://ga4gh.org/fhir/phenopackets/StructureDefinition/biosample-individual-age-at-collection"
+    "biosample-individual-age-at-collection": "http://ga4gh.org/fhir/phenopackets/StructureDefinition/biosample-individual-age-at-collection",
+    "histological_diagnosis": "http://ga4gh.org/fhir/phenopackets/StructureDefinition/biosample-histological-diagnosis",
+    "tumor_progression": "http://ga4gh.org/fhir/phenopackets/StructureDefinition/biosample-tumor-progression",
+    "tumor_grade": "http://ga4gh.org/fhir/phenopackets/StructureDefinition/biosample-tumor-grade",
+    "diagnostic_markers": "http://ga4gh.org/fhir/phenopackets/StructureDefinition/biosample-diagnostic-markers"
+
 }

--- a/chord_metadata_service/restapi/ga4gh_fhir_profiles.py
+++ b/chord_metadata_service/restapi/ga4gh_fhir_profiles.py
@@ -1,3 +1,5 @@
+# Allf fixed values provided by Pheno_FHIR Mapping guide
+# TODO split by some logic
 GA4GH_FHIR_PROFILES = {
     "individual-age": "http://ga4gh.org/fhir/phenopackets/StructureDefinition/individual-age",
     "individual-karyotypic-sex": {
@@ -26,7 +28,62 @@ GA4GH_FHIR_PROFILES = {
     # FHIR
     "region_studied": "http://hl7.org/fhir/uv/genomics-reporting/StructureDefinition/region-studied",
     "disease-onset": "http://ga4gh.org/fhir/phenopackets/StructureDefinition/disease-onset",
-    "disease-tumor-stage": "http://ga4gh.org/fhir/phenopackets/StructureDefinition/disease-tumor-stage"
+    "disease-tumor-stage": "http://ga4gh.org/fhir/phenopackets/StructureDefinition/disease-tumor-stage",
+    # fixed values for sections in phenopacket-composition
+    # TODO split
+    "phenopacket": {
+        "title": "Phenopacket",
+        "code": {
+            "system": "http://ga4gh.org/fhir/phenopackets/CodeSystem/document-type",
+            "code": "phenopacket"
+        }
+    },
+
+    "phenotypic_features": {
+        "title": "Phenotypic Features",
+        "code": {
+            "system": "http://ga4gh.org/fhir/phenopackets/CodeSystem/section-type",
+            "version": "0.1.0",
+            "code": "phenotypic-features",
+            "display": "Phenotypic Features"
+        }
+    },
+    "biosamples": {
+        "title": "Biosamples",
+        "code": {
+            "system": "http://ga4gh.org/fhir/phenopackets/CodeSystem/section-type",
+            "version": "0.1.0",
+            "code": "biosamples",
+            "display": "Biosamples"
+        }
+    },
+    "variants": {
+        "title": "Variants",
+        "code": {
+            "system": "http://ga4gh.org/fhir/phenopackets/CodeSystem/section-type",
+            "version": "0.1.0",
+            "code": "variants",
+            "display": "Variants"
+        }
+    },
+    "diseases": {
+        "title": "Diseases",
+        "code": {
+            "system": "http://ga4gh.org/fhir/phenopackets/CodeSystem/section-type",
+            "version": "0.1.0",
+            "code": "diseases",
+            "display": "Diseases"
+        }
+    },
+    "hts_files": {
+        "title": "HTS Files",
+        "code": {
+            "system": "http://ga4gh.org/fhir/phenopackets/CodeSystem/section-type",
+            "version": "0.1.0",
+            "code": "hts-files",
+            "display": "HTS Files"
+        }
+    }
 }
 
 

--- a/chord_metadata_service/restapi/ga4gh_fhir_profiles.py
+++ b/chord_metadata_service/restapi/ga4gh_fhir_profiles.py
@@ -24,8 +24,9 @@ GA4GH_FHIR_PROFILES = {
     "hts_file": "http://ga4gh.org/fhir/phenopackets/StructureDefinition/HtsFile",
     "genome_assembly": "http://ga4gh.org/fhir/phenopackets/StructureDefinition/htsfile-genome-assembly",
     # FHIR
-    "region_studied": "http://hl7.org/fhir/uv/genomics-reporting/StructureDefinition/region-studied"
-
+    "region_studied": "http://hl7.org/fhir/uv/genomics-reporting/StructureDefinition/region-studied",
+    "disease-onset": "http://ga4gh.org/fhir/phenopackets/StructureDefinition/disease-onset",
+    "disease-tumor-stage": "http://ga4gh.org/fhir/phenopackets/StructureDefinition/disease-tumor-stage"
 }
 
 

--- a/chord_metadata_service/restapi/hl7_genomics_mapping.py
+++ b/chord_metadata_service/restapi/hl7_genomics_mapping.py
@@ -1,0 +1,24 @@
+# All fixed values provided by Phenopackets on FHIR Mapping guide
+# Mappings from http://build.fhir.org/ig/HL7/genomics-reporting/index.html
+
+HL7_GENOMICS_MAPPING = {
+    "gene": {
+        "url": "http://hl7.org/fhir/uv/genomics-reporting/StructureDefinition/region-studied",
+        "gene_studied_code": {
+            "system": "https://loinc.org",
+            "id": "48018-6",
+            "label": "Gene studied [ID]"
+        },
+        "gene_studied_value": {
+            "system": "https://www.genenames.org/"
+        }
+    },
+    "variant": {
+        "url": "http://hl7.org/fhir/uv/genomics-reporting/StructureDefinition/variant",
+        "variant_length_code": {
+            "system": "https://loinc.org",
+            "id": "81300-6",
+            "label": "Structural variant [Length]"
+        }
+    }
+}

--- a/chord_metadata_service/restapi/phenopackets_on_fhir_mapping.py
+++ b/chord_metadata_service/restapi/phenopackets_on_fhir_mapping.py
@@ -1,5 +1,5 @@
-# All fixed values provided by Pheno_FHIR Mapping guide
-# TODO split by some logic
+# All fixed values provided by Phenopackets on FHIR Mapping guide
+
 PHENOPACKETS_ON_FHIR_MAPPING = {
     "individual": {
         "title": "Individual",
@@ -103,108 +103,5 @@ PHENOPACKETS_ON_FHIR_MAPPING = {
         "url": "http://ga4gh.org/fhir/phenopackets/StructureDefinition/Disease",
         "onset": "http://ga4gh.org/fhir/phenopackets/StructureDefinition/disease-onset",
         "disease_stage": "http://ga4gh.org/fhir/phenopackets/StructureDefinition/disease-tumor-stage",
-    }
-}
-
-
-GA4GH_FHIR_PROFILES = {
-    "individual-age": "http://ga4gh.org/fhir/phenopackets/StructureDefinition/individual-age",
-    "individual-karyotypic-sex": {
-        "url": "http://ga4gh.org/fhir/phenopackets/StructureDefinition/individual-karyotypic-sex",
-        "coding_system": "http://ga4gh.org/fhir/phenopackets/CodeSystem/karyotypic-sex"
-    },
-    "individual-taxonomy": "http://ga4gh.org/fhir/phenopackets/StructureDefinition/individual-taxonomy",
-    "biosample-individual-age-at-collection": "http://ga4gh.org/fhir/phenopackets/StructureDefinition/biosample-individual-age-at-collection",
-    "histological_diagnosis": "http://ga4gh.org/fhir/phenopackets/StructureDefinition/biosample-histological-diagnosis",
-    "tumor_progression": "http://ga4gh.org/fhir/phenopackets/StructureDefinition/biosample-tumor-progression",
-    "tumor_grade": "http://ga4gh.org/fhir/phenopackets/StructureDefinition/biosample-tumor-grade",
-    "diagnostic_markers": "http://ga4gh.org/fhir/phenopackets/StructureDefinition/biosample-diagnostic-markers",
-    "is_control_sample": "http://ga4gh.org/fhir/phenopackets/StructureDefinition/biosample-control",
-    "severity": "http://ga4gh.org/fhir/phenopackets/StructureDefinition/phenotypic-feature-severity",
-    "modifier": "http://ga4gh.org/fhir/phenopackets/StructureDefinition/phenotypic-feature-modifier",
-    "onset": "http://ga4gh.org/fhir/phenopackets/StructureDefinition/phenotypic-feature-onset",
-    "evidence": "http://ga4gh.org/fhir/phenopackets/StructureDefinition/evidence",
-    "reference": "http://ga4gh.org/fhir/phenopackets/StructureDefinition/external-reference",
-    # GA4GH guide provides hardcoded values
-    "evidence_code": "evidenceCode",
-    "extension_id_url": "id",
-    "extension_description_url": "description",
-    "document_reference_status": "current",
-    "hts_file": "http://ga4gh.org/fhir/phenopackets/StructureDefinition/HtsFile",
-    "genome_assembly": "http://ga4gh.org/fhir/phenopackets/StructureDefinition/htsfile-genome-assembly",
-    # FHIR
-    "region_studied": "http://hl7.org/fhir/uv/genomics-reporting/StructureDefinition/region-studied",
-    "disease-onset": "http://ga4gh.org/fhir/phenopackets/StructureDefinition/disease-onset",
-    "disease-tumor-stage": "http://ga4gh.org/fhir/phenopackets/StructureDefinition/disease-tumor-stage",
-    # fixed values for sections in phenopacket-composition
-    # TODO split
-    "phenopacket": {
-        "title": "Phenopacket",
-        "code": {
-            "system": "http://ga4gh.org/fhir/phenopackets/CodeSystem/document-type",
-            "code": "phenopacket"
-        }
-    },
-
-    "phenotypic_features": {
-        "title": "Phenotypic Features",
-        "code": {
-            "system": "http://ga4gh.org/fhir/phenopackets/CodeSystem/section-type",
-            "version": "0.1.0",
-            "code": "phenotypic-features",
-            "display": "Phenotypic Features"
-        }
-    },
-    "biosamples": {
-        "title": "Biosamples",
-        "code": {
-            "system": "http://ga4gh.org/fhir/phenopackets/CodeSystem/section-type",
-            "version": "0.1.0",
-            "code": "biosamples",
-            "display": "Biosamples"
-        }
-    },
-    "variants": {
-        "title": "Variants",
-        "code": {
-            "system": "http://ga4gh.org/fhir/phenopackets/CodeSystem/section-type",
-            "version": "0.1.0",
-            "code": "variants",
-            "display": "Variants"
-        }
-    },
-    "diseases": {
-        "title": "Diseases",
-        "code": {
-            "system": "http://ga4gh.org/fhir/phenopackets/CodeSystem/section-type",
-            "version": "0.1.0",
-            "code": "diseases",
-            "display": "Diseases"
-        }
-    },
-    "hts_files": {
-        "title": "HTS Files",
-        "code": {
-            "system": "http://ga4gh.org/fhir/phenopackets/CodeSystem/section-type",
-            "version": "0.1.0",
-            "code": "hts-files",
-            "display": "HTS Files"
-        }
-    }
-}
-
-
-HL7_GENOMICS_REPORTING = {
-    "observation_component_gene_studied": {
-        "system": "https://loinc.org",
-        "id": "48018-6",
-        "label": "Gene studied [ID]"
-    },
-    "HGNC": "https://www.genenames.org/",
-    "variant": "http://hl7.org/fhir/uv/genomics-reporting/StructureDefinition/variant",
-    "observation_component_variant": {
-        "system": "https://loinc.org",
-        "id": "81300-6",
-        "label": "Structural variant [Length]"
     }
 }

--- a/chord_metadata_service/restapi/tests/test_fhir.py
+++ b/chord_metadata_service/restapi/tests/test_fhir.py
@@ -92,6 +92,22 @@ class FHIRPhenotypicFeatureTest(APITestCase):
                          'description')
 
 
+class FHIRProcedureTest(APITestCase):
+
+    def setUp(self):
+        self.valid_procedure = VALID_PROCEDURE_1
+
+    def test_get_fhir(self):
+        response = get_response('procedure-list', self.valid_procedure)
+        get_resp = self.client.get('/api/procedures?format=fhir')
+        self.assertEqual(get_resp.status_code, status.HTTP_200_OK)
+        get_resp_obj = get_resp.json()
+        print(get_resp_obj)
+        self.assertIsNotNone(get_resp_obj['specimen.collections'][0]['method'])
+        self.assertIsInstance(get_resp_obj['specimen.collections'][0]['bodySite'], dict)
+        self.assertIsNot(get_resp_obj['specimen.collections'][0]['method']['coding'], [])
+
+
 class FHIRBiosampleTest(APITestCase):
     """ Test module for creating an Biosample. """
 
@@ -100,7 +116,7 @@ class FHIRBiosampleTest(APITestCase):
         self.procedure = VALID_PROCEDURE_1
         self.valid_payload = valid_biosample_1(self.individual.id, self.procedure)
 
-    def test_create_biosample(self):
+    def test_get_fhir(self):
         """ POST a new biosample. """
 
         response = get_response('biosample-list', self.valid_payload)
@@ -123,7 +139,7 @@ class FHIRHtsFileTest(APITestCase):
     def setUp(self):
         self.hts_file = VALID_HTS_FILE
 
-    def test_hts_file(self):
+    def test_get_fhir(self):
         response = get_response('htsfile-list', self.hts_file)
         get_resp = self.client.get('/api/htsfiles?format=fhir')
         self.assertEqual(get_resp.status_code, status.HTTP_200_OK)
@@ -143,7 +159,7 @@ class FHIRGeneTest(APITestCase):
     def setUp(self):
         self.gene = VALID_GENE_1
 
-    def test_gene(self):
+    def test_get_fhir(self):
         response = get_response('gene-list', self.gene)
         get_resp = self.client.get('/api/genes?format=fhir')
         self.assertEqual(get_resp.status_code, status.HTTP_200_OK)
@@ -163,7 +179,7 @@ class FHIRVariantTest(APITestCase):
     def setUp(self):
         self.variant = VALID_VARIANT_1
 
-    def test_variant(self):
+    def test_get_fhir(self):
         response = get_response('variant-list', self.variant)
         get_resp = self.client.get('/api/variants?format=fhir')
         self.assertEqual(get_resp.status_code, status.HTTP_200_OK)
@@ -182,7 +198,7 @@ class FHIRDiseaseTest(APITestCase):
     def setUp(self):
         self.disease = VALID_DISEASE_1
 
-    def test_disease(self):
+    def test_get_fhir(self):
         response = get_response('disease-list', self.disease)
         get_resp = self.client.get('/api/diseases?format=fhir')
         self.assertEqual(get_resp.status_code, status.HTTP_200_OK)

--- a/chord_metadata_service/restapi/tests/test_fhir.py
+++ b/chord_metadata_service/restapi/tests/test_fhir.py
@@ -151,3 +151,24 @@ class FHIRGeneTest(APITestCase):
         self.assertIsInstance(get_resp_obj['observations'][0]['valueCodeableConcept']['coding'], list)
         self.assertEqual(get_resp_obj['observations'][0]['valueCodeableConcept']['coding'][0]['system'],
                          'https://www.genenames.org/')
+
+
+class FHIRVariantTest(APITestCase):
+
+    def setUp(self):
+        self.variant = VALID_VARIANT_1
+        self.variant_2 = VALID_VARIANT_2
+
+    def test_variant(self):
+        response = get_response('variant-list', self.variant)
+        get_resp = self.client.get('/api/variants?format=fhir')
+        self.assertEqual(get_resp.status_code, status.HTTP_200_OK)
+        get_resp_obj = get_resp.json()
+        print(get_resp_obj)
+        self.assertIsInstance(get_resp_obj['observations'], list)
+        self.assertIsInstance(get_resp_obj['observations'][0]['code']['coding'], list)
+        self.assertEqual(get_resp_obj['observations'][0]['code']['coding'][0]['code'], '81300-6')
+        self.assertEqual(get_resp_obj['observations'][0]['code']['coding'][0]['display'], 'Structural variant [Length]')
+        self.assertEqual(get_resp_obj['observations'][0]['code']['coding'][0]['system'], 'https://loinc.org')
+        self.assertEqual(get_resp_obj['observations'][0]['valueCodeableConcept']['coding'][0]['code'],
+                         get_resp_obj['observations'][0]['valueCodeableConcept']['coding'][0]['display'])

--- a/chord_metadata_service/restapi/tests/test_fhir.py
+++ b/chord_metadata_service/restapi/tests/test_fhir.py
@@ -1,7 +1,9 @@
 from rest_framework.test import APITestCase
 from chord_metadata_service.phenopackets.tests.constants import *
+from chord_metadata_service.patients.tests.constants import *
 from chord_metadata_service.phenopackets.tests.test_api import get_response
 from chord_metadata_service.phenopackets.serializers import *
+from rest_framework import status
 
 
 class FHIRPhenopacketTest(APITestCase):
@@ -19,7 +21,7 @@ class FHIRPhenopacketTest(APITestCase):
     def test_get_fhir(self):
         response = get_response('phenopacket-list', self.phenopacket)
         get_resp = self.client.get('/api/phenopackets?format=fhir')
-        self.assertEqual(get_resp.status_code, 200)
+        self.assertEqual(get_resp.status_code, status.HTTP_200_OK)
         get_resp_obj = get_resp.json()
         self.assertEqual(get_resp_obj['compositions'][0]['resourceType'], 'Composition')
         self.assertEqual(get_resp_obj['compositions'][0]['title'], 'Phenopacket')
@@ -27,3 +29,18 @@ class FHIRPhenopacketTest(APITestCase):
                          'http://ga4gh.org/fhir/phenopackets/CodeSystem/document-type')
         self.assertEqual(get_resp_obj['compositions'][0]['status'], 'preliminary')
         self.assertIsInstance(get_resp_obj['compositions'][0]['subject']['reference'], str)
+
+
+class FHIRIndividualTest(APITestCase):
+    """ Test module for creating an Individual. """
+
+    def setUp(self):
+        self.individual = VALID_INDIVIDUAL
+
+    def test_create_individual(self):
+        response = get_response('individual-list', self.individual)
+        get_resp = self.client.get('/api/individuals?format=fhir')
+        self.assertEqual(get_resp.status_code, status.HTTP_200_OK)
+        get_resp_obj = get_resp.json()
+        self.assertEqual(get_resp_obj['patients'][0]['resourceType'], 'Patient')
+        self.assertIsInstance(get_resp_obj['patients'][0]['extension'], list)

--- a/chord_metadata_service/restapi/tests/test_fhir.py
+++ b/chord_metadata_service/restapi/tests/test_fhir.py
@@ -37,14 +37,19 @@ class FHIRIndividualTest(APITestCase):
 
     def setUp(self):
         self.individual = VALID_INDIVIDUAL
+        self.individual_second = VALID_INDIVIDUAL_2
 
     def test_get_fhir(self):
-        response = get_response('individual-list', self.individual)
+        response_1 = get_response('individual-list', self.individual)
+        response_2 = get_response('individual-list', self.individual_second)
         get_resp = self.client.get('/api/individuals?format=fhir')
         self.assertEqual(get_resp.status_code, status.HTTP_200_OK)
         get_resp_obj = get_resp.json()
         self.assertEqual(get_resp_obj['patients'][0]['resourceType'], 'Patient')
         self.assertIsInstance(get_resp_obj['patients'][0]['extension'], list)
+        self.assertEqual(get_resp_obj['patients'][1]['extension'][0]['url'],
+                         'http://ga4gh.org/fhir/phenopackets/StructureDefinition/individual-age')
+        self.assertIsInstance(get_resp_obj['patients'][1]['extension'][0]['valueAge'], dict)
 
 
 class FHIRPhenotypicFeatureTest(APITestCase):

--- a/chord_metadata_service/restapi/tests/test_fhir.py
+++ b/chord_metadata_service/restapi/tests/test_fhir.py
@@ -1,0 +1,29 @@
+from rest_framework.test import APITestCase
+from chord_metadata_service.phenopackets.tests.constants import *
+from chord_metadata_service.phenopackets.tests.test_api import get_response
+from chord_metadata_service.phenopackets.serializers import *
+
+
+class FHIRPhenopacketTest(APITestCase):
+
+    def setUp(self):
+        individual = Individual.objects.create(**VALID_INDIVIDUAL_1)
+        self.subject = individual.id
+        meta = MetaData.objects.create(**VALID_META_DATA_2)
+        self.metadata = meta.id
+        self.phenopacket = valid_phenopacket(
+            subject=self.subject,
+            meta_data=self.metadata)
+
+
+    def test_get_fhir(self):
+        response = get_response('phenopacket-list', self.phenopacket)
+        get_resp = self.client.get('/api/phenopackets?format=fhir')
+        self.assertEqual(get_resp.status_code, 200)
+        get_resp_obj = get_resp.json()
+        self.assertEqual(get_resp_obj['compositions'][0]['resourceType'], 'Composition')
+        self.assertEqual(get_resp_obj['compositions'][0]['title'], 'Phenopacket')
+        self.assertEqual(get_resp_obj['compositions'][0]['type']['coding'][0]['system'],
+                         'http://ga4gh.org/fhir/phenopackets/CodeSystem/document-type')
+        self.assertEqual(get_resp_obj['compositions'][0]['status'], 'preliminary')
+        self.assertIsInstance(get_resp_obj['compositions'][0]['subject']['reference'], str)

--- a/chord_metadata_service/restapi/tests/test_fhir.py
+++ b/chord_metadata_service/restapi/tests/test_fhir.py
@@ -85,3 +85,30 @@ class FHIRPhenotypicFeatureTest(APITestCase):
                               'http://ga4gh.org/fhir/phenopackets/StructureDefinition/evidence')
         self.assertEqual(get_resp_obj['observations'][0]['extension'][3]['extension'][1]['extension'][1]['url'],
                          'description')
+
+
+class CreateBiosampleTest(APITestCase):
+    """ Test module for creating an Biosample. """
+
+    def setUp(self):
+        self.individual = Individual.objects.create(**VALID_INDIVIDUAL_1)
+        self.procedure = VALID_PROCEDURE_1
+        self.valid_payload = valid_biosample_1(self.individual.id, self.procedure)
+
+    def test_create_biosample(self):
+        """ POST a new biosample. """
+
+        response = get_response('biosample-list', self.valid_payload)
+        get_resp = self.client.get('/api/biosamples?format=fhir')
+        self.assertEqual(get_resp.status_code, status.HTTP_200_OK)
+        get_resp_obj = get_resp.json()
+        self.assertEqual(get_resp_obj['specimens'][0]['resourceType'], 'Specimen')
+        self.assertIsNotNone(get_resp_obj['specimens'][0]['type']['coding'][0])
+        self.assertIsNotNone(get_resp_obj['specimens'][0]['collection'])
+        self.assertIsInstance(get_resp_obj['specimens'][0]['extension'][0]['valueRange'], dict)
+        self.assertEqual(get_resp_obj['specimens'][0]['extension'][4]['url'],
+                         'http://ga4gh.org/fhir/phenopackets/StructureDefinition/biosample-diagnostic-markers')
+        self.assertIsInstance(get_resp_obj['specimens'][0]['extension'][4]['valueCodeableConcept']['coding'],
+                         list)
+        self.assertTrue(get_resp_obj['specimens'][0]['extension'][5]['valueBoolean'])
+        

--- a/chord_metadata_service/restapi/tests/test_fhir.py
+++ b/chord_metadata_service/restapi/tests/test_fhir.py
@@ -123,7 +123,6 @@ class FHIRHtsFileTest(APITestCase):
         get_resp = self.client.get('/api/htsfiles?format=fhir')
         self.assertEqual(get_resp.status_code, status.HTTP_200_OK)
         get_resp_obj = get_resp.json()
-        print(get_resp_obj)
         self.assertEqual(get_resp_obj['document_references'][0]['resourceType'], 'DocumentReference')
         self.assertIsInstance(get_resp_obj['document_references'][0]['content'], list)
         self.assertIsNotNone(get_resp_obj['document_references'][0]['content'][0]['attachment']['url'])
@@ -132,3 +131,23 @@ class FHIRHtsFileTest(APITestCase):
                          get_resp_obj['document_references'][0]['type']['coding'][0]['display'])
         self.assertEqual(get_resp_obj['document_references'][0]['extension'][0]['url'],
                          'http://ga4gh.org/fhir/phenopackets/StructureDefinition/htsfile-genome-assembly')
+
+
+class FHIRGeneTest(APITestCase):
+
+    def setUp(self):
+        self.gene = VALID_GENE_1
+
+    def test_gene(self):
+        response = get_response('gene-list', self.gene)
+        get_resp = self.client.get('/api/genes?format=fhir')
+        self.assertEqual(get_resp.status_code, status.HTTP_200_OK)
+        get_resp_obj = get_resp.json()
+        self.assertIsInstance(get_resp_obj['observations'], list)
+        self.assertIsInstance(get_resp_obj['observations'][0]['code']['coding'], list)
+        self.assertEqual(get_resp_obj['observations'][0]['code']['coding'][0]['code'], '48018-6')
+        self.assertEqual(get_resp_obj['observations'][0]['code']['coding'][0]['display'], 'Gene studied [ID]')
+        self.assertEqual(get_resp_obj['observations'][0]['code']['coding'][0]['system'], 'https://loinc.org')
+        self.assertIsInstance(get_resp_obj['observations'][0]['valueCodeableConcept']['coding'], list)
+        self.assertEqual(get_resp_obj['observations'][0]['valueCodeableConcept']['coding'][0]['system'],
+                         'https://www.genenames.org/')

--- a/chord_metadata_service/restapi/tests/test_fhir.py
+++ b/chord_metadata_service/restapi/tests/test_fhir.py
@@ -157,14 +157,12 @@ class FHIRVariantTest(APITestCase):
 
     def setUp(self):
         self.variant = VALID_VARIANT_1
-        self.variant_2 = VALID_VARIANT_2
 
     def test_variant(self):
         response = get_response('variant-list', self.variant)
         get_resp = self.client.get('/api/variants?format=fhir')
         self.assertEqual(get_resp.status_code, status.HTTP_200_OK)
         get_resp_obj = get_resp.json()
-        print(get_resp_obj)
         self.assertIsInstance(get_resp_obj['observations'], list)
         self.assertIsInstance(get_resp_obj['observations'][0]['code']['coding'], list)
         self.assertEqual(get_resp_obj['observations'][0]['code']['coding'][0]['code'], '81300-6')
@@ -172,3 +170,22 @@ class FHIRVariantTest(APITestCase):
         self.assertEqual(get_resp_obj['observations'][0]['code']['coding'][0]['system'], 'https://loinc.org')
         self.assertEqual(get_resp_obj['observations'][0]['valueCodeableConcept']['coding'][0]['code'],
                          get_resp_obj['observations'][0]['valueCodeableConcept']['coding'][0]['display'])
+
+
+class FHIRDiseaseTest(APITestCase):
+
+    def setUp(self):
+        self.disease = VALID_DISEASE_1
+
+    def test_disease(self):
+        response = get_response('disease-list', self.disease)
+        get_resp = self.client.get('/api/diseases?format=fhir')
+        self.assertEqual(get_resp.status_code, status.HTTP_200_OK)
+        get_resp_obj = get_resp.json()
+        self.assertEqual(get_resp_obj['conditions'][0]['resourceType'], 'Condition')
+        self.assertIsNotNone(get_resp_obj['conditions'][0]['code']['coding'][0])
+        self.assertIsInstance(get_resp_obj['conditions'][0]['extension'], list)
+        self.assertEqual(get_resp_obj['conditions'][0]['extension'][0]['url'],
+                              'http://ga4gh.org/fhir/phenopackets/StructureDefinition/disease-tumor-stage')
+        self.assertEqual(get_resp_obj['conditions'][0]['subject']['reference'], 'unknown')
+        

--- a/chord_metadata_service/restapi/tests/test_fhir.py
+++ b/chord_metadata_service/restapi/tests/test_fhir.py
@@ -83,3 +83,5 @@ class FHIRPhenotypicFeatureTest(APITestCase):
         self.assertEqual(get_resp_obj['observations'][0]['interpretation']['coding'][0]['code'], 'POS')
         self.assertEqual(get_resp_obj['observations'][0]['extension'][3]['url'],
                               'http://ga4gh.org/fhir/phenopackets/StructureDefinition/evidence')
+        self.assertEqual(get_resp_obj['observations'][0]['extension'][3]['extension'][1]['extension'][1]['url'],
+                         'description')

--- a/chord_metadata_service/restapi/tests/test_fhir.py
+++ b/chord_metadata_service/restapi/tests/test_fhir.py
@@ -87,7 +87,7 @@ class FHIRPhenotypicFeatureTest(APITestCase):
                          'description')
 
 
-class CreateBiosampleTest(APITestCase):
+class FHIRBiosampleTest(APITestCase):
     """ Test module for creating an Biosample. """
 
     def setUp(self):
@@ -111,4 +111,24 @@ class CreateBiosampleTest(APITestCase):
         self.assertIsInstance(get_resp_obj['specimens'][0]['extension'][4]['valueCodeableConcept']['coding'],
                          list)
         self.assertTrue(get_resp_obj['specimens'][0]['extension'][5]['valueBoolean'])
-        
+
+
+class FHIRHtsFileTest(APITestCase):
+
+    def setUp(self):
+        self.hts_file = VALID_HTS_FILE
+
+    def test_hts_file(self):
+        response = get_response('htsfile-list', self.hts_file)
+        get_resp = self.client.get('/api/htsfiles?format=fhir')
+        self.assertEqual(get_resp.status_code, status.HTTP_200_OK)
+        get_resp_obj = get_resp.json()
+        print(get_resp_obj)
+        self.assertEqual(get_resp_obj['document_references'][0]['resourceType'], 'DocumentReference')
+        self.assertIsInstance(get_resp_obj['document_references'][0]['content'], list)
+        self.assertIsNotNone(get_resp_obj['document_references'][0]['content'][0]['attachment']['url'])
+        self.assertEqual(get_resp_obj['document_references'][0]['status'], 'current')
+        self.assertEqual(get_resp_obj['document_references'][0]['type']['coding'][0]['code'],
+                         get_resp_obj['document_references'][0]['type']['coding'][0]['display'])
+        self.assertEqual(get_resp_obj['document_references'][0]['extension'][0]['url'],
+                         'http://ga4gh.org/fhir/phenopackets/StructureDefinition/htsfile-genome-assembly')

--- a/chord_metadata_service/restapi/tests/test_fhir.py
+++ b/chord_metadata_service/restapi/tests/test_fhir.py
@@ -37,7 +37,7 @@ class FHIRIndividualTest(APITestCase):
     def setUp(self):
         self.individual = VALID_INDIVIDUAL
 
-    def test_create_individual(self):
+    def test_get_fhir(self):
         response = get_response('individual-list', self.individual)
         get_resp = self.client.get('/api/individuals?format=fhir')
         self.assertEqual(get_resp.status_code, status.HTTP_200_OK)

--- a/chord_metadata_service/restapi/utils.py
+++ b/chord_metadata_service/restapi/utils.py
@@ -1,0 +1,26 @@
+def camel_case_field_names(string):
+    """ Function to convert snake_case field names to camelCase """
+
+    if '_' in string:
+        splitted = string.split('_')
+        capitilized = []
+        capitilized.append(splitted[0])
+        for each in splitted[1:]:
+            capitilized.append(each.title())
+        return ''.join(capitilized)
+    return string
+
+
+def transform_keys(obj):
+    """
+    The function validates against DATS schemas that use camelCase.
+    It iterates over a dict and changes all keys in nested objects to camelCase.
+    """
+
+    if isinstance(obj, dict):
+        transformed_obj = {}
+        for key, value in obj.items():
+            if isinstance(value, dict):
+                value = transform_keys(value)
+            transformed_obj[camel_case_field_names(key)] = value
+        return transformed_obj

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,8 +11,10 @@ django-filter==2.2.0
 django-nose==1.4.6
 djangorestframework==3.10.3
 djangorestframework-camel-case==1.1.2
+fhirclient==3.2.0
 idna==2.8
 importlib-metadata==1.3.0
+isodate==0.6.0
 itypes==1.1.0
 Jinja2==2.10.3
 jsonschema==3.2.0

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ setuptools.setup(
     python_requires=">=3.6",
     install_requires=["chord_lib @ git+https://github.com/c3g/chord_lib", "Django==2.2.8", "django-filter",
                       "django-nose", "djangorestframework", "djangorestframework-camel-case", "jsonschema",
-                      "psycopg2-binary", "python-dateutil", "PyYAML", "requests", "uritemplate"],
+                      "psycopg2-binary", "python-dateutil", "PyYAML", "requests", "uritemplate", "fhirclient"],
 
     author="Ksenia Zaytseva",
 


### PR DESCRIPTION
- Used [smart-on-fhir Python client](https://github.com/smart-on-fhir/client-py) to rewrite converter functions for all classes.
- The client provides validation against FHIR 4.0.
- Important: update of fhir client might be needed in the future when the official version 4 is released, see [issue](https://github.com/smart-on-fhir/client-py/issues/70)
- Added tests