### PR TITLE
Add always_include option for generic serializer

### DIFF
--- a/chord_metadata_service/chord/serializers.py
+++ b/chord_metadata_service/chord/serializers.py
@@ -20,6 +20,8 @@ __all__ = ["ProjectSerializer", "DatasetSerializer", "TableOwnershipSerializer"]
 
 
 class DatasetSerializer(GenericSerializer):
+    always_include = ("linked_field_sets",)
+
     # noinspection PyMethodMayBeStatic
     def validate_title(self, value):
         if len(value.strip()) < 3:

--- a/chord_metadata_service/chord/serializers.py
+++ b/chord_metadata_service/chord/serializers.py
@@ -20,7 +20,11 @@ __all__ = ["ProjectSerializer", "DatasetSerializer", "TableOwnershipSerializer"]
 
 
 class DatasetSerializer(GenericSerializer):
-    always_include = ("linked_field_sets",)
+    always_include = (
+        "description",
+        "contact_info",
+        "linked_field_sets",
+    )
 
     # noinspection PyMethodMayBeStatic
     def validate_title(self, value):

--- a/chord_metadata_service/restapi/serializers.py
+++ b/chord_metadata_service/restapi/serializers.py
@@ -1,9 +1,11 @@
 from rest_framework import serializers
 from collections import OrderedDict
+from typing import Tuple
 
 
 class GenericSerializer(serializers.ModelSerializer):
     """ Subclass of ModelSerializer """
+    always_include: Tuple[str, ...] = ()
 
     def __init__(self, *args, **kwargs):
         exclude_when_nested = kwargs.pop('exclude_when_nested', None)
@@ -17,5 +19,5 @@ class GenericSerializer(serializers.ModelSerializer):
         """ Return only not empty fields """
         final_object = super().to_representation(instance)
         # filter null values and create new dict
-        final_object = OrderedDict(list(filter(lambda x: x[1], final_object.items())))
+        final_object = OrderedDict(list(filter(lambda x: x[1] or x[0] in self.always_include, final_object.items())))
         return final_object


### PR DESCRIPTION
Fields listed here will always be included, even if false-y
Use it for dataset linked field sets to fix deletion of linked field sets