### PR TITLE
Add test for jsonld and rdf renderers

### DIFF
--- a/chord_metadata_service/phenopackets/tests/test_api.py
+++ b/chord_metadata_service/phenopackets/tests/test_api.py
@@ -1,22 +1,8 @@
-import json
-from django.urls import reverse
 from rest_framework import status
 from rest_framework.test import APITestCase
 from .constants import *
 from ..serializers import *
-from rest_framework.test import APIClient
-
-
-def get_response(viewname, obj):
-    """ Generic POST function. """
-
-    client = APIClient()
-    response = client.post(
-        reverse(viewname),
-        data=json.dumps(obj),
-        content_type='application/json'
-    )
-    return response
+from chord_metadata_service.restapi.tests.utils import get_response
 
 
 class CreateBiosampleTest(APITestCase):

--- a/chord_metadata_service/restapi/semantic_mappings/context.py
+++ b/chord_metadata_service/restapi/semantic_mappings/context.py
@@ -34,6 +34,7 @@ CONTEXT = [
         "@type": "sdo:Text"
       },
       "primary_publications": "sdo:citation",
+      "Publication": "sdo:ScholarlyArticle",
       "citations": "sdo:citation",
       "produced_by": "sdo:producer",
       "creators": {

--- a/chord_metadata_service/restapi/tests/test_fhir.py
+++ b/chord_metadata_service/restapi/tests/test_fhir.py
@@ -1,7 +1,7 @@
 from rest_framework.test import APITestCase
 from chord_metadata_service.phenopackets.tests.constants import *
 from chord_metadata_service.patients.tests.constants import *
-from chord_metadata_service.phenopackets.tests.test_api import get_response
+from chord_metadata_service.restapi.tests.utils import get_response
 from chord_metadata_service.phenopackets.serializers import *
 from rest_framework import status
 

--- a/chord_metadata_service/restapi/tests/test_jsonld.py
+++ b/chord_metadata_service/restapi/tests/test_jsonld.py
@@ -23,3 +23,9 @@ class JSONLDDatasetTest(APITestCase):
         self.assertIsInstance(get_resp_obj['results'][0]['@context'], list)
         self.assertIsNotNone(get_resp_obj['results'][0]['@context'], True)
         self.assertEqual(get_resp_obj['results'][0]['@type'], 'Dataset')
+
+    def test_rdf(self):
+        get_resp = self.client.get('/api/datasets?format=rdf')
+        self.assertEqual(get_resp.status_code, status.HTTP_200_OK)
+        self.assertEqual(get_resp.accepted_media_type, 'application/rdf+xml')
+        self.assertIsInstance(get_resp.content, bytes)

--- a/chord_metadata_service/restapi/tests/test_jsonld.py
+++ b/chord_metadata_service/restapi/tests/test_jsonld.py
@@ -1,0 +1,25 @@
+from rest_framework.test import APITestCase
+from django.test import override_settings
+from rest_framework import status
+from chord_metadata_service.chord.tests.constants import (VALID_PROJECT_1,
+                    VALID_DATS_CREATORS, dats_dataset)
+from chord_metadata_service.restapi.tests.utils import get_response
+
+
+class JSONLDDatasetTest(APITestCase):
+    @override_settings(AUTH_OVERRIDE=True)
+    def setUp(self) -> None:
+        project = get_response('project-list', VALID_PROJECT_1)
+        self.project = project.json()
+        self.creators = VALID_DATS_CREATORS
+        self.dataset = dats_dataset(self.project['identifier'], self.creators)
+        resp = get_response('dataset-list', self.dataset)
+
+
+    def test_jsonld(self):
+        get_resp = self.client.get('/api/datasets?format=json-ld')
+        get_resp_obj = get_resp.json()
+        self.assertEqual(get_resp.status_code, status.HTTP_200_OK)
+        self.assertIsInstance(get_resp_obj['results'][0]['@context'], list)
+        self.assertIsNotNone(get_resp_obj['results'][0]['@context'], True)
+        self.assertEqual(get_resp_obj['results'][0]['@type'], 'Dataset')

--- a/chord_metadata_service/restapi/tests/utils.py
+++ b/chord_metadata_service/restapi/tests/utils.py
@@ -1,0 +1,16 @@
+import json
+from django.urls import reverse
+from rest_framework.test import APIClient
+
+# Helper functions for tests
+
+def get_response(viewname, obj):
+    """ Generic POST function. """
+
+    client = APIClient()
+    response = client.post(
+        reverse(viewname),
+        data=json.dumps(obj),
+        content_type='application/json'
+    )
+    return response


### PR DESCRIPTION
- added two tests
- moved get_response() in restapi.tests.utils because it's used in tests in different apps