### PR TITLE
Centralize pagination class and handle reverse proxied uris

### DIFF
--- a/chord_metadata_service/chord/api_views.py
+++ b/chord_metadata_service/chord/api_views.py
@@ -1,6 +1,6 @@
 from rest_framework import viewsets
 from rest_framework.permissions import BasePermission, SAFE_METHODS
-from chord_metadata_service.phenopackets.api_views import LargeResultsSetPagination
+from chord_metadata_service.restapi.pagination import LargeResultsSetPagination
 from .models import *
 from .permissions import OverrideOrSuperUserOnly
 from .serializers import *

--- a/chord_metadata_service/chord/views_search.py
+++ b/chord_metadata_service/chord/views_search.py
@@ -1,6 +1,5 @@
 import itertools
 from datetime import datetime
-import json
 
 from django.db import connection
 from django.conf import settings

--- a/chord_metadata_service/chord/views_search.py
+++ b/chord_metadata_service/chord/views_search.py
@@ -167,6 +167,8 @@ def chord_search(request):
     return search(request, internal_data=False)
 
 
+# Mounted on /private/, so will get protected anyway; this allows for access from federation service
+# TODO: Ugly and misleading permissions
 @api_view(["POST"])
 @permission_classes([AllowAny])
 def chord_private_search(request):
@@ -262,13 +264,18 @@ def fhir_public_search(request):
     return fhir_search(request)
 
 
+# Mounted on /private/, so will get protected anyway
+# TODO: Ugly and misleading permissions
 @api_view(["POST"])
 @permission_classes([AllowAny])
 def fhir_private_search(request):
     return fhir_search(request, internal_data=True)
 
 
+# Mounted on /private/, so will get protected anyway; this allows for access from federation service
+# TODO: Ugly and misleading permissions
 @api_view(["POST"])
+@permission_classes([AllowAny])
 def chord_private_table_search(request, table_id):
     # Search phenopacket data types in specific tables
     # Private search endpoints are protected by URL namespace, not by Django permissions.

--- a/chord_metadata_service/metadata/settings.py
+++ b/chord_metadata_service/metadata/settings.py
@@ -38,6 +38,8 @@ APPEND_SLASH = False
 
 # CHORD-specific settings
 
+CHORD_URL = os.environ.get("CHORD_URL", None)  # Leave None if not specified, for running in other contexts
+
 # SECURITY WARNING: Don't run with CHORD_PERMISSIONS turned off in production,
 # unless an alternative permissions system is in place.
 CHORD_PERMISSIONS = os.environ.get("CHORD_PERMISSIONS", str(not DEBUG)).lower() == "true"

--- a/chord_metadata_service/patients/api_views.py
+++ b/chord_metadata_service/patients/api_views.py
@@ -1,4 +1,4 @@
-from rest_framework import viewsets, pagination
+from rest_framework import viewsets
 from rest_framework.settings import api_settings
 from .serializers import IndividualSerializer
 from .models import Individual
@@ -7,12 +7,7 @@ from chord_metadata_service.restapi.api_renderers import (
     FHIRRenderer,
     PhenopacketsRenderer
 )
-
-
-class LargeResultsSetPagination(pagination.PageNumberPagination):
-    page_size = 25
-    page_size_query_param = 'page_size'
-    max_page_size = 10000
+from chord_metadata_service.restapi.pagination import LargeResultsSetPagination
 
 
 class IndividualViewSet(viewsets.ModelViewSet):

--- a/chord_metadata_service/phenopackets/api_views.py
+++ b/chord_metadata_service/phenopackets/api_views.py
@@ -1,14 +1,10 @@
-from rest_framework import viewsets, pagination
+from rest_framework import viewsets
+from rest_framework.settings import api_settings
+
+from chord_metadata_service.restapi.api_renderers import *
+from chord_metadata_service.restapi.pagination import LargeResultsSetPagination
 from .serializers import *
 from .models import *
-from rest_framework.settings import api_settings
-from chord_metadata_service.restapi.api_renderers import *
-
-
-class LargeResultsSetPagination(pagination.PageNumberPagination):
-    page_size = 25
-    page_size_query_param = 'page_size'
-    max_page_size = 10000
 
 
 class PhenopacketsModelViewSet(viewsets.ModelViewSet):

--- a/chord_metadata_service/restapi/pagination.py
+++ b/chord_metadata_service/restapi/pagination.py
@@ -1,6 +1,5 @@
 from django.conf import settings
 from rest_framework import pagination
-from rest_framework.utils.urls import remove_query_param, replace_query_param
 from urllib.parse import urljoin
 
 

--- a/chord_metadata_service/restapi/pagination.py
+++ b/chord_metadata_service/restapi/pagination.py
@@ -14,7 +14,7 @@ class LargeResultsSetPagination(pagination.PageNumberPagination):
     page_size_query_param = 'page_size'
     max_page_size = 10000
 
-    # Fix next/previous links inside sub-path-mounted reverse proxies in the CHORD context
+    # Fix next/previous links inside sub-path-mounted reverse proxies in the CHORD context:
 
     def _get_chord_absolute_uri(self):
         full_path = self.request.get_full_path()
@@ -24,25 +24,19 @@ class LargeResultsSetPagination(pagination.PageNumberPagination):
         return urljoin(settings.CHORD_URL, full_path)
 
     def get_next_link(self):
-        if not self.page.has_next():
-            return None
-
         if settings.CHORD_URL is not None:
-            url = self._get_chord_absolute_uri()
-            page_number = self.page.next_page_number()
-            return replace_query_param(url, self.page_query_param, page_number)
-
+            # Monkey-patch rewrite build_absolute_uri
+            self.request.build_absolute_uri = self._get_chord_absolute_uri
         return super(LargeResultsSetPagination, self).get_next_link()
 
     def get_previous_link(self):
-        if not self.page.has_previous():
-            return None
-
         if settings.CHORD_URL is not None:
-            url = self._get_chord_absolute_uri()
-            page_number = self.page.next_page_number()
-            if page_number == 1:
-                return remove_query_param(url, self.page_query_param)
-            return replace_query_param(url, self.page_query_param, page_number)
-
+            # Monkey-patch rewrite build_absolute_uri
+            self.request.build_absolute_uri = self._get_chord_absolute_uri
         return super(LargeResultsSetPagination, self).get_previous_link()
+
+    def get_html_context(self):
+        if settings.CHORD_URL is not None:
+            # Monkey-patch rewrite build_absolute_uri
+            self.request.build_absolute_uri = self._get_chord_absolute_uri
+        super(LargeResultsSetPagination, self).get_html_context()

--- a/chord_metadata_service/restapi/pagination.py
+++ b/chord_metadata_service/restapi/pagination.py
@@ -1,0 +1,44 @@
+from django.conf import settings
+from rest_framework import pagination
+from rest_framework.utils.urls import remove_query_param, replace_query_param
+from urllib.parse import urljoin
+
+
+__all__ = [
+    "LargeResultsSetPagination",
+]
+
+
+class LargeResultsSetPagination(pagination.PageNumberPagination):
+    page_size = 25
+    page_size_query_param = 'page_size'
+    max_page_size = 10000
+
+    # Fix next/previous links inside sub-path-mounted reverse proxies in the CHORD context
+
+    def _get_chord_absolute_uri(self):
+        return urljoin(settings.CHORD_URL, self.request.get_full_path())
+
+    def get_next_link(self):
+        if not self.page.has_next():
+            return None
+
+        if settings.CHORD_URL is not None:
+            url = self._get_chord_absolute_uri()
+            page_number = self.page.next_page_number()
+            return replace_query_param(url, self.page_query_param, page_number)
+
+        return super(LargeResultsSetPagination, self).get_next_link()
+
+    def get_previous_link(self):
+        if not self.page.has_previous():
+            return None
+
+        if settings.CHORD_URL is not None:
+            url = self._get_chord_absolute_uri()
+            page_number = self.page.next_page_number()
+            if page_number == 1:
+                return remove_query_param(url, self.page_query_param)
+            return replace_query_param(url, self.page_query_param, page_number)
+
+        return super(LargeResultsSetPagination, self).get_previous_link()

--- a/chord_metadata_service/restapi/pagination.py
+++ b/chord_metadata_service/restapi/pagination.py
@@ -17,7 +17,11 @@ class LargeResultsSetPagination(pagination.PageNumberPagination):
     # Fix next/previous links inside sub-path-mounted reverse proxies in the CHORD context
 
     def _get_chord_absolute_uri(self):
-        return urljoin(settings.CHORD_URL, self.request.get_full_path())
+        full_path = self.request.get_full_path()
+        # Strip first slash if necessary, to avoid urljoin removing reverse proxy sub-paths
+        if len(full_path) > 0 and full_path[0] == "/":
+            full_path = full_path[1:]
+        return urljoin(settings.CHORD_URL, full_path)
 
     def get_next_link(self):
         if not self.page.has_next():


### PR DESCRIPTION
Previously, reverse proxies mounted on sub-URLs were not being
handled correctly by Django. If CHORD_URL is set, it can be used
to correctly generate absolute URIs in pagination contexts.

Also fixes a permissions issue with private table search.