### PR TITLE
Add filtering for Individual

### DIFF
--- a/chord_metadata_service/metadata/settings.py
+++ b/chord_metadata_service/metadata/settings.py
@@ -84,7 +84,7 @@ INSTALLED_APPS = [
     'chord_metadata_service.restapi.apps.RestapiConfig',
 
     'corsheaders',
-
+    'django_filters',
     'rest_framework',
     'django_nose',
     'rest_framework_swagger',
@@ -196,7 +196,8 @@ REST_FRAMEWORK = {
         'djangorestframework_camel_case.parser.CamelCaseMultiPartParser',
     ),
     'DEFAULT_PERMISSION_CLASSES': ['chord_metadata_service.chord.permissions.OverrideOrSuperUserOnly'],
-    'DEFAULT_SCHEMA_CLASS': 'rest_framework.schemas.coreapi.AutoSchema'
+    'DEFAULT_SCHEMA_CLASS': 'rest_framework.schemas.coreapi.AutoSchema',
+    'DEFAULT_FILTER_BACKENDS': ['django_filters.rest_framework.DjangoFilterBackend']
 }
 
 # Password validation

--- a/chord_metadata_service/patients/api_views.py
+++ b/chord_metadata_service/patients/api_views.py
@@ -1,5 +1,6 @@
-from rest_framework import viewsets
+from rest_framework import viewsets, filters
 from rest_framework.settings import api_settings
+from django_filters.rest_framework import DjangoFilterBackend
 from .serializers import IndividualSerializer
 from .models import Individual
 from chord_metadata_service.phenopackets.api_views import BIOSAMPLE_PREFETCH, PHENOPACKET_PREFETCH
@@ -23,3 +24,6 @@ class IndividualViewSet(viewsets.ModelViewSet):
     serializer_class = IndividualSerializer
     pagination_class = LargeResultsSetPagination
     renderer_classes = (*api_settings.DEFAULT_RENDERER_CLASSES, FHIRRenderer, PhenopacketsRenderer)
+    filter_backends = [DjangoFilterBackend, filters.SearchFilter]
+    filterset_fields = ["id", "sex", "ethnicity"]
+    search_fields = ["sex", "ethnicity"]

--- a/chord_metadata_service/patients/api_views.py
+++ b/chord_metadata_service/patients/api_views.py
@@ -3,6 +3,7 @@ from rest_framework.settings import api_settings
 from django_filters.rest_framework import DjangoFilterBackend
 from .serializers import IndividualSerializer
 from .models import Individual
+from .filters import IndividualFilter
 from chord_metadata_service.phenopackets.api_views import BIOSAMPLE_PREFETCH, PHENOPACKET_PREFETCH
 from chord_metadata_service.restapi.api_renderers import FHIRRenderer, PhenopacketsRenderer
 from chord_metadata_service.restapi.pagination import LargeResultsSetPagination
@@ -25,6 +26,6 @@ class IndividualViewSet(viewsets.ModelViewSet):
     pagination_class = LargeResultsSetPagination
     renderer_classes = (*api_settings.DEFAULT_RENDERER_CLASSES, FHIRRenderer, PhenopacketsRenderer)
     filter_backends = [DjangoFilterBackend, filters.SearchFilter, filters.OrderingFilter]
-    filterset_fields = ["id", "sex", "ethnicity"]
+    filter_class = IndividualFilter
     ordering_fields = ["id"]
     search_fields = ["sex", "ethnicity"]

--- a/chord_metadata_service/patients/api_views.py
+++ b/chord_metadata_service/patients/api_views.py
@@ -24,6 +24,7 @@ class IndividualViewSet(viewsets.ModelViewSet):
     serializer_class = IndividualSerializer
     pagination_class = LargeResultsSetPagination
     renderer_classes = (*api_settings.DEFAULT_RENDERER_CLASSES, FHIRRenderer, PhenopacketsRenderer)
-    filter_backends = [DjangoFilterBackend, filters.SearchFilter]
+    filter_backends = [DjangoFilterBackend, filters.SearchFilter, filters.OrderingFilter]
     filterset_fields = ["id", "sex", "ethnicity"]
+    ordering_fields = ["id"]
     search_fields = ["sex", "ethnicity"]

--- a/chord_metadata_service/patients/filters.py
+++ b/chord_metadata_service/patients/filters.py
@@ -1,0 +1,12 @@
+import django_filters
+from .models import *
+
+
+class IndividualFilter(django_filters.rest_framework.FilterSet):
+    id = django_filters.AllValuesMultipleFilter()
+    sex = django_filters.CharFilter(lookup_expr='iexact')
+    ethnicity = django_filters.CharFilter(lookup_expr='iexact')
+
+    class Meta:
+        model = Individual
+        fields = ["id", "sex", "ethnicity"]

--- a/chord_metadata_service/patients/filters.py
+++ b/chord_metadata_service/patients/filters.py
@@ -1,5 +1,5 @@
 import django_filters
-from .models import *
+from .models import Individual
 
 
 class IndividualFilter(django_filters.rest_framework.FilterSet):


### PR DESCRIPTION
1. filter by id, sex or ethnicity, uses exact match and case-insensitive, e.g.:

`api/individuals?id=002-28-7813` or multiple `?id=002-28-7813&id=002-98-6165&id=001-77-5311`

`api/individuals?sex=female&ethnicity=hispanic`


2. search by sex or ethnicity, uses full-text search on these two fields, partial match and case-insensitive

`api/individuals?search=male`

