### PR TITLE
Candig authz part 2

### DIFF
--- a/chord_metadata_service/restapi/middleware.py
+++ b/chord_metadata_service/restapi/middleware.py
@@ -1,5 +1,6 @@
 from django.conf import settings
 from django.http import HttpResponseForbidden
+import jwt
 import requests
 
 
@@ -17,8 +18,14 @@ class CandigAuthzMiddleware:
 
     def __call__(self, request):
         if settings.INSIDE_CANDIG and self.is_applicable_endpoint(request):
-            # TODO: unpack the JWT and get access level
-            access_level = 4
+            # TODO: So currently I'm assuming the frontend will query the
+            # dataset info beforehand so as to be able to include it here
+            # so we know which authz rule to apply
+            # Bit clumsy, consider this a stop-gap measure
+            access_level = self.decode_permissions(request)
+
+            if not access_level:
+                return HttpResponseForbidden()
 
             try:
                 allowed = self.query_opa(request, access_level)
@@ -32,6 +39,30 @@ class CandigAuthzMiddleware:
 
     def is_applicable_endpoint(self, request):
         return request.path in APPLICABLE_ENDPOINTS
+
+    def decode_permissions(self, request):
+        if 'X-CanDIG-Dataset' not in request.headers:
+            return
+        else:
+            dataset = request.headers.get('X-CanDIG-Dataset')
+
+        if 'X-CanDIG-Authz' in request.headers:
+            authz_jwt = request.headers.get("X-CanDIG-Authz").split(' ')[1]
+            # TODO: yes it is a terrible idea to decode without checking the
+            # the signature, gotta find a proper way to transmit vault's public key
+            decoded_jwt = jwt.decode(authz_jwt, verify=False)
+
+            if 'permissions' in decoded_jwt:
+                permissions = decoded_jwt.get('permissions')
+
+                # TODO: I am assuming the permission object is a simple dict such as
+                # {"DATASET_NAME": 4}
+                # TODO: would make sense to package this feature, the reading of the
+                # permission object in a lib, since we'll repeat that stuff over many services
+                if dataset in permissions:
+                    return permissions[dataset]
+                else:
+                    return
 
     def query_opa(self, request, access_level):
         if not settings.CANDIG_OPA_URL:

--- a/chord_metadata_service/restapi/middleware.py
+++ b/chord_metadata_service/restapi/middleware.py
@@ -72,7 +72,7 @@ class CandigAuthzMiddleware:
             "input": {
                 "path": request.path,
                 "method": request.method,
-                "access_level": access_level
+                "access_level": int(access_level)
             }
         }
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -43,6 +43,7 @@ psycopg2-binary==2.8.5
 py==1.9.0
 pycodestyle==2.6.0
 pyflakes==2.2.0
+PyJWT[crypto]==1.7.1
 Pygments==2.6.1
 pyparsing==2.4.7
 pyrsistent==0.16.0


### PR DESCRIPTION
The first part created this middleware and called OPA when inside CanDIG. This PR completes the feature, namely extracting the access_level (which OPA needs) from the request.