### PR TITLE
Patch/leaner queries

### DIFF
--- a/chord_metadata_service/chord/views_search.py
+++ b/chord_metadata_service/chord/views_search.py
@@ -276,6 +276,11 @@ def get_field_lookup(field):
 
 def get_values_list(queryset, options):
     field_lookup = get_field_lookup(options.get("field", []))
+
+    # Filter out null values because these values will be used to make joins,
+    # or fetch back some records.
+    queryset = queryset.filter(**{f"{field_lookup}__isnull": False})
+
     if "add_field" in options:
         # Return a list of the dict, with the additional field and the field
         # used for the value. It will require further processing to get a list

--- a/chord_metadata_service/patients/api_views.py
+++ b/chord_metadata_service/patients/api_views.py
@@ -18,6 +18,7 @@ from chord_metadata_service.restapi.api_renderers import (
     PhenopacketsRenderer,
     IndividualCSVRenderer,
     ARGORenderer,
+    IndividualBentoSearchRenderer,
 )
 from chord_metadata_service.restapi.pagination import LargeResultsSetPagination, BatchResultsSetPagination
 from chord_metadata_service.restapi.utils import (
@@ -44,7 +45,8 @@ class IndividualViewSet(viewsets.ModelViewSet):
     serializer_class = IndividualSerializer
     pagination_class = LargeResultsSetPagination
     renderer_classes = (*api_settings.DEFAULT_RENDERER_CLASSES, FHIRRenderer,
-                        PhenopacketsRenderer, IndividualCSVRenderer, ARGORenderer)
+                        PhenopacketsRenderer, IndividualCSVRenderer, ARGORenderer,
+                        IndividualBentoSearchRenderer)
     filter_backends = [DjangoFilterBackend, filters.OrderingFilter]
     filter_class = IndividualFilter
     ordering_fields = ["id"]
@@ -68,7 +70,8 @@ class IndividualBatchViewSet(BatchViewSet):
     serializer_class = IndividualSerializer
     pagination_class = BatchResultsSetPagination
     renderer_classes = (*api_settings.DEFAULT_RENDERER_CLASSES, FHIRRenderer,
-                        PhenopacketsRenderer, IndividualCSVRenderer, ARGORenderer)
+                        PhenopacketsRenderer, IndividualCSVRenderer, ARGORenderer,
+                        IndividualBentoSearchRenderer)
     # Override to infer the renderer based on a `format` argument from the POST request body
     content_negotiation_class = FormatInPostContentNegotiation
 

--- a/chord_metadata_service/patients/tests/test_api.py
+++ b/chord_metadata_service/patients/tests/test_api.py
@@ -165,6 +165,13 @@ class IndividualFullTextSearchTest(APITestCase):
         response_obj_2 = get_resp_2.json()
         self.assertEqual(len(response_obj_2['results']), 2)
 
+    def test_search_bento_search_format(self):
+        get_resp_1 = self.client.get('/api/individuals?search=P49Y&format=bento_search_result')
+        self.assertEqual(get_resp_1.status_code, status.HTTP_200_OK)
+        response_obj_1 = get_resp_1.json()
+        self.assertEqual(len(response_obj_1['results']), 1)
+        self.assertEqual(len(response_obj_1['results'][0]), 4)  # 4 fields in the bento search response
+
 
 # Note: the next five tests use the same setUp method. Initially they were
 # all combined in the same class. But this caused bugs with regard to unavailable

--- a/chord_metadata_service/restapi/api_renderers.py
+++ b/chord_metadata_service/restapi/api_renderers.py
@@ -181,12 +181,14 @@ class IndividualBentoSearchRenderer(JSONRenderer):
                 'biosamples': [],
                 'num_experiments': 0
             }
-            if 'biosamples' in individual:
+            if 'phenopackets' in individual:
                 ids = []
-                for biosample in individual['biosamples']:
-                    ids.append(biosample['id'])
-                    if 'experiments' in biosample:
-                        ind_obj['num_experiments'] += len(biosample['experiments'])
+                for p in individual['phenopackets']:
+                    if 'biosamples' in p:
+                        for biosample in p['biosamples']:
+                            ids.append(biosample['id'])
+                            if 'experiments' in biosample:
+                                ind_obj['num_experiments'] += len(biosample['experiments'])
                 ind_obj['biosamples'] = ids
             individuals.append(ind_obj)
         data['results'] = individuals

--- a/chord_metadata_service/restapi/api_renderers.py
+++ b/chord_metadata_service/restapi/api_renderers.py
@@ -173,11 +173,8 @@ class IndividualBentoSearchRenderer(JSONRenderer):
     format = OUTPUT_FORMAT_BENTO_SEARCH_RESULT
 
     def render(self, data, media_type=None, renderer_context=None):
-        if 'results' not in data or not data['results']:
-            return
-
         individuals = []
-        for individual in data['results']:
+        for individual in data.get('results', []):
             ind_obj = {
                 'subject_id': individual['id'],
                 'alternate_ids': individual.get('alternate_ids', []),   # may be NULL

--- a/chord_metadata_service/restapi/api_renderers.py
+++ b/chord_metadata_service/restapi/api_renderers.py
@@ -179,7 +179,7 @@ class IndividualBentoSearchRenderer(JSONRenderer):
         individuals = []
         for individual in data['results']:
             ind_obj = {
-                'id': individual['id'],
+                'subject_id': individual['id'],
                 'alternate_ids': individual.get('alternate_ids', []),   # may be NULL
                 'biosamples': [],
                 'num_experiments': 0


### PR DESCRIPTION
This PR complements the previous `features/leaner-queries` with the following fixes or improvements:
- implement bento-search-results format for the Individuals endpoint
- filter out null values when querying for a values list for a specific field