### PR TITLE
Features/stats list

### DIFF
--- a/chord_metadata_service/patients/api_views.py
+++ b/chord_metadata_service/patients/api_views.py
@@ -140,26 +140,25 @@ class PublicListIndividuals(APIView):
                 *(e.error_list if hasattr(e, "error_list") else e.error_dict.items()),
             ))
 
-        if filtered_qs.count() > settings.CONFIG_PUBLIC["rules"]["count_threshold"]:
-            tissues_count, sampled_tissues = get_queryset_stats(
-                filtered_qs,
-                "phenopackets__biosamples__sampled_tissue"
-            )
-            experiments_count, experiment_type = get_queryset_stats(
-                filtered_qs,
-                "phenopackets__biosamples__experiment__experiment_type"
-            )
-            return Response({
-                "count": filtered_qs.count(),
-                "biosamples": {
-                    "count": tissues_count,
-                    "sampled_tissue": sampled_tissues
-                },
-                "experiments": {
-                    "count": experiments_count,
-                    "experiment_type": experiment_type
-                }
-            })
-        else:
-            # the count < threshold when there is no match in db the queryset is empty, count = 0
+        if filtered_qs.count() <= settings.CONFIG_PUBLIC["rules"]["count_threshold"]:
             return Response(settings.INSUFFICIENT_DATA_AVAILABLE)
+
+        tissues_count, sampled_tissues = get_queryset_stats(
+            filtered_qs,
+            "phenopackets__biosamples__sampled_tissue"
+        )
+        experiments_count, experiment_type = get_queryset_stats(
+            filtered_qs,
+            "phenopackets__biosamples__experiment__experiment_type"
+        )
+        return Response({
+            "count": filtered_qs.count(),
+            "biosamples": {
+                "count": tissues_count,
+                "sampled_tissue": sampled_tissues
+            },
+            "experiments": {
+                "count": experiments_count,
+                "experiment_type": experiment_type
+            }
+        })

--- a/chord_metadata_service/patients/api_views.py
+++ b/chord_metadata_service/patients/api_views.py
@@ -145,7 +145,7 @@ class PublicListIndividuals(APIView):
 
         tissues_count, sampled_tissues = get_queryset_stats(
             filtered_qs,
-            "phenopackets__biosamples__sampled_tissue"
+            "phenopackets__biosamples__sampled_tissue__label"
         )
         experiments_count, experiment_type = get_queryset_stats(
             filtered_qs,

--- a/chord_metadata_service/patients/tests/test_api.py
+++ b/chord_metadata_service/patients/tests/test_api.py
@@ -288,6 +288,10 @@ class PublicListIndividualsTest(APITestCase):
             self.assertEqual(response_obj, settings.INSUFFICIENT_DATA_AVAILABLE)
         else:
             self.assertEqual(Individual.objects.all().count(), response_obj['count'])
+            self.assertEqual(response_obj['biosamples']['count'], 0)
+            self.assertIsInstance(response_obj['biosamples']['sampled_tissue'], list)
+            self.assertEqual(response_obj['experiments']['count'], 0)
+            self.assertIsInstance(response_obj['experiments']['experiment_type'], list)
 
     @override_settings(CONFIG_PUBLIC={})
     def test_public_get_no_config(self):

--- a/chord_metadata_service/restapi/api_views.py
+++ b/chord_metadata_service/restapi/api_views.py
@@ -74,7 +74,7 @@ def overview(_request):
     # age_numeric is computed at ingestion time of phenopackets. On some instances
     # it might be unavailable and as a fallback must be computed from the age JSON field which
     # has two alternate formats (hence more complex and slower to process)
-    individuals_age = get_field_bins(patients_models.Individual, "age_numeric", OVERVIEW_AGE_BIN_SIZE)
+    individuals_age = get_field_bins(patients_models.Individual.objects.all(), "age_numeric", OVERVIEW_AGE_BIN_SIZE)
     if None in individuals_age:  # fallback
         del individuals_age[None]
         individuals_age = Counter(individuals_age)

--- a/chord_metadata_service/restapi/api_views.py
+++ b/chord_metadata_service/restapi/api_views.py
@@ -146,7 +146,7 @@ def search_overview(request):
         queryset = queryset.filter(id__in=individual_id)
 
     biosamples_count = queryset.values("phenopackets__biosamples__id").count()
-    experiments_count = queryset.values("phenopackets__experiments__id").count()
+    experiments_count = queryset.values("phenopackets__biosamples__experiment__id").count()
 
     # Sex related fields stats are precomputed here and post processed later
     # to include missing values inferred from the schema
@@ -173,7 +173,10 @@ def search_overview(request):
         },
         "experiments": {
             "count": experiments_count,
-            "experiment_type": queryset_stats_for_field(queryset, "phenopackets__experiments__experiment_type"),
+            "experiment_type": queryset_stats_for_field(
+                queryset,
+                "phenopackets__biosamples__experiment__experiment_type"
+            ),
         },
     }
     return Response(r)

--- a/chord_metadata_service/restapi/api_views.py
+++ b/chord_metadata_service/restapi/api_views.py
@@ -136,10 +136,9 @@ def search_overview(request):
     get+post:
     Overview statistics of a list of patients (associated with a search result)
     - Parameter
-        - id: an arrays of patient ids
+        - id: a list of patient ids
     """
-    query_params = request.query_params if request.method == "GET" else (request.data or {})
-    individual_id = query_params.get("id", [])
+    individual_id = request.GET.getlist("id") if request.method == "GET" else request.data.get("id", [])
 
     queryset = patients_models.Individual.objects.all()
     if len(individual_id) > 0:

--- a/chord_metadata_service/restapi/tests/test_api.py
+++ b/chord_metadata_service/restapi/tests/test_api.py
@@ -1,3 +1,4 @@
+import json
 import os
 from copy import deepcopy
 
@@ -102,6 +103,17 @@ class OverviewTest(APITestCase):
         self.assertEqual(response_obj['data_type_specific']['instruments']['count'], 1)
         self.assertEqual(response_obj['data_type_specific']['instruments']['platform']['Illumina'], 2)
         self.assertEqual(response_obj['data_type_specific']['instruments']['model']['Illumina HiSeq 4000'], 2)
+
+    def test_search_overview(self):
+        payload = json.dumps({'id': [ph_c.VALID_INDIVIDUAL_1['id']]})
+        response = self.client.post(reverse('search-overview'), payload, content_type='application/json')
+        response_obj = response.json()
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertIsInstance(response_obj, dict)
+        self.assertEqual(response_obj['biosamples']['count'], 1)
+        self.assertIn('wall of urinary bladder', response_obj['biosamples']['sampled_tissue'])
+        self.assertIn('Proptosis', response_obj['phenotypic_features']['type'])
+        self.assertIn(ph_c.VALID_DISEASE_1['term']['label'], response_obj['diseases']['term'])
 
 
 class McodeOverviewTest(APITestCase):

--- a/chord_metadata_service/restapi/urls.py
+++ b/chord_metadata_service/restapi/urls.py
@@ -18,6 +18,7 @@ from .api_views import (
      public_search_fields,
      public_overview,
      public_dataset,
+     search_overview
 )
 from chord_metadata_service.restapi.routers import BatchListRouter
 
@@ -83,6 +84,8 @@ urlpatterns = [
     path('overview', overview, name="overview"),
     # mcode overview
     path('mcode_overview', mcode_overview, name="mcode-overview"),
+    # search overview
+    path('search_overview', search_overview, name="search-overview"),
     # autocomplete URLs
     path('disease_term_autocomplete', DiseaseTermAutocomplete.as_view(), name='disease-term-autocomplete',),
     path('phenotypic_feature_type_autocomplete', PhenotypicFeatureTypeAutocomplete.as_view(),

--- a/chord_metadata_service/restapi/urls.py
+++ b/chord_metadata_service/restapi/urls.py
@@ -73,6 +73,7 @@ router.register(r'resources', resources_views.ResourceViewSet)
 urlpatterns = [
     path('', include(router.urls)),
     path('', include(batch_router.urls)),
+
     # apps schemas
     path('chord_phenopacket_schema', phenopacket_views.get_chord_phenopacket_schema,
          name="chord-phenopacket-schema"),
@@ -80,25 +81,23 @@ urlpatterns = [
          name="experiment-schema"),
     path('mcode_schema', mcode_views.get_mcode_schema,
          name="mcode-schema"),
-    # overview
+
+    # overviews (statistics)
     path('overview', overview, name="overview"),
-    # mcode overview
     path('mcode_overview', mcode_overview, name="mcode-overview"),
-    # search overview
     path('search_overview', search_overview, name="search-overview"),
+
     # autocomplete URLs
     path('disease_term_autocomplete', DiseaseTermAutocomplete.as_view(), name='disease-term-autocomplete',),
     path('phenotypic_feature_type_autocomplete', PhenotypicFeatureTypeAutocomplete.as_view(),
          name='phenotypic-feature-type-autocomplete',),
     path('biosample_sampled_tissue_autocomplete', BiosampleSampledTissueAutocomplete.as_view(),
          name='biosample-sampled-tissue-autocomplete',),
-    # public search results
+
+    # public endpoints (no confidential information leak)
     path('public', individual_views.PublicListIndividuals.as_view(),
          name='public',),
-    # public search fields schema
     path('public_search_fields', public_search_fields, name='public-search-fields',),
-    # public overview
     path('public_overview', public_overview, name='public-overview',),
-    # public dataset properties
     path('public_dataset', public_dataset, name='public-dataset'),
 ]

--- a/chord_metadata_service/restapi/utils.py
+++ b/chord_metadata_service/restapi/utils.py
@@ -225,12 +225,12 @@ def queryset_stats_for_field(queryset, field: str, add_missing=False) -> Mapping
     return stats
 
 
-def get_field_bins(model, field, bin_size):
+def get_field_bins(query_set, field, bin_size):
     # computes a new column "binned" by substracting the modulo by bin size to
     # the value which requires binning (e.g. 28 => 28 - 28 % 10 = 20)
     # cast to integer to avoid numbers such as 60.00 if that was a decimal,
     # and aggregate over this value.
-    query_set = model.objects.all().annotate(
+    query_set = query_set.annotate(
         binned=Cast(
             F(field) - Func(F(field), bin_size, function="MOD"),
             IntegerField()

--- a/chord_metadata_service/restapi/utils.py
+++ b/chord_metadata_service/restapi/utils.py
@@ -299,7 +299,7 @@ def get_queryset_stats(queryset, field):
         total += value
     if total <= threshold:
         total = 0
-    return bins, total
+    return total, bins
 
 
 def get_categorical_stats(field_props):


### PR DESCRIPTION
This branch adds some statistics on filtered results for certain fields. This functionality is used for 2 new features, which are grouped in this branch:
- new endpoint: api/search_overview. This endpoint receives a POST request with the following payload:
```json
{
    "id": ["patient:1", "patient:2",...]
}
```
and it returns an object with various statistics (counts of biosamples and experiments for this subset, detailed aggregated statistics for some fields (sampled_tissue, histological_diagnosis...). See the following ticket for requirements: https://206.12.92.46/issues/1258
The goal is to provide an overview of search results in the Bento UI.
- api/public endpoint: previously was returning only a count of results. This commit adds statistics about sampled_tissue and experiment_type. See the following ticket for requirements https://206.12.92.46/issues/1211

How to test:
The test suite has been updated in regard with those changes
- for the public interface, one can perform a search such as `api/public?sex=male`
- for the search_overview, using the demo dataset I've tried the following `api/search_overview?id=ind:NA19648&id=ind:HG00096`
ideally this should be tested in the context of bento_web when the implementation of fetching search results is completed.