### PR TITLE
Fix/table summary

### DIFF
--- a/chord_metadata_service/chord/views_search.py
+++ b/chord_metadata_service/chord/views_search.py
@@ -179,30 +179,30 @@ def mcodepacket_table_summary(table):
 
 
 def phenopacket_table_summary(table):
-    phenopackets = Phenopacket.objects.filter(table=table)  # TODO
+    phenopacket_qs = Phenopacket.objects.filter(table=table)  # TODO
 
     # Sex related fields stats are precomputed here and post processed later
     # to include missing values inferred from the schema
-    individuals_sex = queryset_stats_for_field(phenopackets, "subject__sex")
-    individuals_k_sex = queryset_stats_for_field(phenopackets, "subject__karyotypic_sex")
+    individuals_sex = queryset_stats_for_field(phenopacket_qs, "subject__sex")
+    individuals_k_sex = queryset_stats_for_field(phenopacket_qs, "subject__karyotypic_sex")
 
     return Response({
-        "count": phenopackets.count(),
+        "count": phenopacket_qs.count(),
         "data_type_specific": {
             "biosamples": {
-                "count": phenopackets.values("biosamples__id").count(),
-                "is_control_sample": queryset_stats_for_field(phenopackets, "biosamples__is_control_sample"),
-                "taxonomy": queryset_stats_for_field(phenopackets, "biosamples__taxonomy__label"),
+                "count": phenopacket_qs.values("biosamples__id").count(),
+                "is_control_sample": queryset_stats_for_field(phenopacket_qs, "biosamples__is_control_sample"),
+                "taxonomy": queryset_stats_for_field(phenopacket_qs, "biosamples__taxonomy__label"),
             },
-            "diseases": queryset_stats_for_field(phenopackets, "diseases__term__label"),
+            "diseases": queryset_stats_for_field(phenopacket_qs, "diseases__term__label"),
             "individuals": {
-                "count": phenopackets.values("subject__id").count(),
+                "count": phenopacket_qs.values("subject__id").count(),
                 "sex": {k: individuals_sex.get(k, 0) for k in (s[0] for s in Individual.SEX)},
                 "karyotypic_sex": {k: individuals_k_sex.get(k, 0) for k in (s[0] for s in Individual.KARYOTYPIC_SEX)},
-                "taxonomy": queryset_stats_for_field(phenopackets, "subject__taxonomy__label"),
+                "taxonomy": queryset_stats_for_field(phenopacket_qs, "subject__taxonomy__label"),
                 # TODO: age histogram
             },
-            "phenotypic_features": queryset_stats_for_field(phenopackets, "phenotypic_features__pftype__label"),
+            "phenotypic_features": queryset_stats_for_field(phenopacket_qs, "phenotypic_features__pftype__label"),
         }
     })
 

--- a/chord_metadata_service/chord/views_search.py
+++ b/chord_metadata_service/chord/views_search.py
@@ -13,7 +13,7 @@ from django.contrib.postgres.aggregates import ArrayAgg
 from django.conf import settings
 from django.views.decorators.cache import cache_page
 from psycopg2 import sql
-from chord_metadata_service.restapi.utils import queryset_stats_for_field
+from chord_metadata_service.restapi.utils import get_field_bins, queryset_stats_for_field
 from rest_framework.decorators import api_view, permission_classes
 from rest_framework.permissions import AllowAny
 from rest_framework.response import Response
@@ -200,7 +200,7 @@ def phenopacket_table_summary(table):
                 "sex": {k: individuals_sex.get(k, 0) for k in (s[0] for s in Individual.SEX)},
                 "karyotypic_sex": {k: individuals_k_sex.get(k, 0) for k in (s[0] for s in Individual.KARYOTYPIC_SEX)},
                 "taxonomy": queryset_stats_for_field(phenopacket_qs, "subject__taxonomy__label"),
-                # TODO: age histogram
+                "age": get_field_bins(phenopacket_qs, "subject__age_numeric", 10),
             },
             "phenotypic_features": queryset_stats_for_field(phenopacket_qs, "phenotypic_features__pftype__label"),
         }

--- a/chord_metadata_service/restapi/utils.py
+++ b/chord_metadata_service/restapi/utils.py
@@ -215,7 +215,11 @@ def queryset_stats_for_field(queryset, field: str, add_missing=False) -> Mapping
         if key is None:
             continue
 
-        key = key.strip()
+        if not isinstance(key, str):
+            key = str(key)
+        else:
+            key = key.strip()
+
         if key == "":
             continue
 


### PR DESCRIPTION
This PR fixes the issue described in the ticket https://206.12.92.46/issues/1038 where the counts for sex are incorrect (doubled).
The implementation relies on the same method as for the overview summary, public overview and search results statistics, which improves the response speed (from 20s to 200ms on the chord_demo dataset).
The age stats have also been added to the response as a comment let think it was the original intent.

## How to test:
- In the context of Bento, use Admin>Data Manager, click on the [Data Tables] tab and find a phenopacket table in the list. Click on the blue link with the table UUID in the first column.
- From Katsu, the endpoint is located at /api/metadata/api/tables/56b44259-1fff-46ef-9f0d-5897fea63eee/summary (where the UUID is the table UUID) and can be checked using the swagger interface at /api/metadata/