### PR TITLE
Features/public config custom

### DIFF
--- a/chord_metadata_service/example.config.json
+++ b/chord_metadata_service/example.config.json
@@ -98,11 +98,8 @@
             "description": "This acts as a placeholder for numeric values",
             "datatype": "number",
             "config": {
-                "bin_size": 50,
-                "taper_left": 50,
-                "taper_right": 800,
+                "bins": [200, 300, 500, 1000, 1500, 2000],
                 "minimum": 0,
-                "maximum": 1000,
                 "units": "mg/L"
             }
         }
@@ -111,4 +108,4 @@
         "count_threshold": 5,
         "max_query_parameters": 2
     }
-  }
+}

--- a/chord_metadata_service/example.config.json
+++ b/chord_metadata_service/example.config.json
@@ -21,6 +21,10 @@
         {
             "section_title": "Demographics",
             "fields": ["age", "sex", "date_of_consent", "lab_test_result_value"]
+        },
+        {
+            "section_title": "Experiments",
+            "fields": ["experiment_type"]
         }
     ],
     "fields": {

--- a/chord_metadata_service/example.config.json
+++ b/chord_metadata_service/example.config.json
@@ -49,6 +49,7 @@
         },
         "experiment_type": {
             "mapping": "experiment/experiment_type",
+            "mapping_for_search_filter": "individual/biosamples/experiment/experiment_type",
             "title": "Experiment Types",
             "description": "Types of experiments performed on a sample",
             "datatype": "string",

--- a/chord_metadata_service/patients/tests/test_api.py
+++ b/chord_metadata_service/patients/tests/test_api.py
@@ -414,13 +414,13 @@ class PublicFilteringIndividualsTest(APITestCase):
     def test_public_filtering_extra_properties_range_1(self):
         # extra_properties range search (both min and max ranges, single value)
         response = self.client.get(
-            '/api/public?lab_test_result_value=50-100'
+            '/api/public?lab_test_result_value=200-300'
         )
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         response_obj = response.json()
         range_parameters = {
-            "extra_properties__lab_test_result_value__gte": 50,
-            "extra_properties__lab_test_result_value__lt": 100
+            "extra_properties__lab_test_result_value__gte": 200,
+            "extra_properties__lab_test_result_value__lt": 300
         }
         db_count = Individual.objects.filter(**range_parameters).count()
         self.assertIn(self.response_threshold_check(response_obj), [db_count, settings.INSUFFICIENT_DATA_AVAILABLE])
@@ -479,14 +479,14 @@ class PublicFilteringIndividualsTest(APITestCase):
     def test_public_filtering_extra_properties_range_string_1(self):
         # sex string search and extra_properties range search
         response = self.client.get(
-            '/api/public?sex=female&lab_test_result_value=100-150'
+            '/api/public?sex=female&lab_test_result_value=< 200'
         )
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         response_obj = response.json()
         range_parameters = {
             "sex__iexact": "female",
-            "extra_properties__lab_test_result_value__gte": 100,
-            "extra_properties__lab_test_result_value__lt": 150
+            "extra_properties__lab_test_result_value__gte": 0,
+            "extra_properties__lab_test_result_value__lt": 200
         }
         db_count = Individual.objects.filter(**range_parameters).count()
         self.assertIn(self.response_threshold_check(response_obj), [db_count, settings.INSUFFICIENT_DATA_AVAILABLE])
@@ -497,15 +497,15 @@ class PublicFilteringIndividualsTest(APITestCase):
 
     @override_settings(CONFIG_PUBLIC=CONFIG_PUBLIC_TEST)
     def test_public_filtering_extra_properties_range_string_2(self):
-        # extra_properties range search (both min and max ranges) and extra_properties string search (single value)
+        # extra_properties range search and extra_properties string search (single value)
         response = self.client.get(
-            '/api/public?lab_test_result_value=100-150&covidstatus=positive'
+            '/api/public?lab_test_result_value=< 200&covidstatus=positive'
         )
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         response_obj = response.json()
         range_parameters = {
-            "extra_properties__lab_test_result_value__gte": 100,
-            "extra_properties__lab_test_result_value__lt": 150,
+            "extra_properties__lab_test_result_value__gte": 0,
+            "extra_properties__lab_test_result_value__lt": 200,
             "extra_properties__covidstatus__iexact": "positive",
         }
         db_count = Individual.objects.filter(**range_parameters).count()
@@ -519,13 +519,13 @@ class PublicFilteringIndividualsTest(APITestCase):
     def test_public_filtering_extra_properties_multiple_ranges_1(self):
         # extra_properties range search (both min and max range, multiple values)
         response = self.client.get(
-            '/api/public?lab_test_result_value=100-150&baseline_creatinine=100-150'
+            '/api/public?lab_test_result_value=< 200&baseline_creatinine=100-150'
         )
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         response_obj = response.json()
         range_parameters = {
-            "extra_properties__lab_test_result_value__gte": 100,
-            "extra_properties__lab_test_result_value__lt": 150,
+            "extra_properties__lab_test_result_value__gte": 0,
+            "extra_properties__lab_test_result_value__lt": 200,
             "extra_properties__baseline_creatinine__gte": 100,
             "extra_properties__baseline_creatinine__lt": 150,
         }
@@ -558,14 +558,14 @@ class PublicFilteringIndividualsTest(APITestCase):
     def test_public_filtering_extra_properties_date_range_and_other_range(self):
         # extra_properties date range search (both after and before, single value) and other number range search
         response = self.client.get(
-            '/api/public?date_of_consent=Mar 2021&lab_test_result_value=100-150'
+            '/api/public?date_of_consent=Mar 2021&lab_test_result_value=< 200'
         )
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         response_obj = response.json()
         range_parameters = {
             "extra_properties__date_of_consent__startswith": "2021-03",
-            "extra_properties__lab_test_result_value__gte": 100,
-            "extra_properties__lab_test_result_value__lt": 150,
+            "extra_properties__lab_test_result_value__gte": 0,
+            "extra_properties__lab_test_result_value__lt": 200,
         }
         db_count = Individual.objects.filter(**range_parameters).count()
         self.assertIn(self.response_threshold_check(response_obj), [db_count, settings.INSUFFICIENT_DATA_AVAILABLE])

--- a/chord_metadata_service/restapi/tests/constants.py
+++ b/chord_metadata_service/restapi/tests/constants.py
@@ -343,11 +343,8 @@ CONFIG_PUBLIC_TEST = {
             "description": "This acts as a placeholder for numeric values",
             "datatype": "number",
             "config": {
-                "bin_size": 50,
-                "taper_left": 50,
-                "taper_right": 800,
+                "bins": [200, 300, 500, 1000, 1500, 2000],
                 "minimum": 0,
-                "maximum": 1000,
                 "units": "mg/L"
             }
         },

--- a/chord_metadata_service/restapi/tests/constants.py
+++ b/chord_metadata_service/restapi/tests/constants.py
@@ -269,7 +269,8 @@ CONFIG_PUBLIC_TEST = {
             "section_title": "First Section",
             "fields": [
                 "sex", "age", "smoking", "covidstatus", "death_dc",
-                "lab_test_result_value", "baseline_creatinine", "date_of_consent"
+                "lab_test_result_value", "baseline_creatinine", "date_of_consent",
+                "tissues"
             ]
         }
     ],
@@ -369,6 +370,16 @@ CONFIG_PUBLIC_TEST = {
             "datatype": "date",
             "config": {
                 "bin_by": "month"
+            }
+        },
+        "tissues": {
+            "mapping": "biosample/sampled_tissue/label",
+            "mapping_for_search_filter": "individual/biosamples/sampled_tissue/label",
+            "title": "Tissue",
+            "description": "Tissue from which the biosample was extracted",
+            "datatype": "string",
+            "config": {
+                "enum": None
             }
         }
     },

--- a/chord_metadata_service/restapi/tests/test_api_utils.py
+++ b/chord_metadata_service/restapi/tests/test_api_utils.py
@@ -67,6 +67,75 @@ class TestLabelledRangeGenerator(TestCase):
         self.assertRaises(ValueError, list, rg)
 
 
+class TestLabelledRangeGeneratorCustomBins(TestCase):
+    def setUp(self):
+        self.fp = {
+            "config": {
+                "bins": [200, 300, 500, 1000, 1500, 2000],
+                "minimum": 0,
+                "units": "mg/L"
+            }
+        }
+
+    def test_custom_bins_config(self):
+        rg = list(labelled_range_generator(self.fp))
+        self.assertEqual(rg[0], (0, 200, "< 200"))
+        self.assertEqual(rg[-1], (2000, None, "≥ 2000"))
+        self.assertEqual(rg[1], (200, 300, "200-300"))
+
+    def test_custom_bins_config_no_open_ended(self):
+        c = {
+            "config": {
+                **self.fp["config"],
+                "minimum": 200,
+                "maximum": 2000
+            }
+        }
+        rg = list(labelled_range_generator(c))
+        self.assertIn("-", rg[0][2])
+        self.assertIn("-", rg[-1][2])
+
+    def test_custom_bins_wrong_min(self):
+        c = {
+            "config": {
+                **self.fp["config"],
+                "minimum": 300
+            }
+        }
+        rg = labelled_range_generator(c)
+        self.assertRaises(ValueError, list, rg)
+
+    def test_custom_bins_wrong_max(self):
+        c = {
+            "config": {
+                **self.fp["config"],
+                "maximum": 300
+            }
+        }
+        rg = labelled_range_generator(c)
+        self.assertRaises(ValueError, list, rg)
+
+    def test_custom_bins_wrong_max_2(self):
+        c = {
+            "config": {
+                **self.fp["config"],
+                "maximum": -10
+            }
+        }
+        rg = labelled_range_generator(c)
+        self.assertRaises(ValueError, list, rg)
+
+    def test_custom_bins_wrong_bins(self):
+        c = {
+            "config": {
+                **self.fp["config"],
+                "bins": [200]
+            }
+        }
+        rg = labelled_range_generator(c)
+        self.assertRaises(ValueError, list, rg)
+
+
 class TestModelField(TestCase):
 
     def test_get_model_field_basic(self):

--- a/chord_metadata_service/restapi/utils.py
+++ b/chord_metadata_service/restapi/utils.py
@@ -246,6 +246,8 @@ def get_model_and_field(field_id: str) -> Tuple[any, str]:
         model = pheno_models.Individual
     elif model_name == "experiment":
         model = experiments_models.Experiment
+    elif model_name == "biosample":
+        model = pheno_models.Biosample
     else:
         msg = f"Accessing field on model {model_name} not implemented"
         raise NotImplementedError(msg)

--- a/chord_metadata_service/restapi/utils.py
+++ b/chord_metadata_service/restapi/utils.py
@@ -556,9 +556,15 @@ def filter_queryset_field_value(qs, field_props, value: str):
     Further filter a queryset using the field defined by field_props and the
     given value.
     It is a prerequisite that the field mapping defined in field_props is represented
-    in the queryset object
+    in the queryset object.
+    `mapping_for_search_filter` is an optional property that gets precedence over `mapping`
+    for the necessity of filtering. It is not necessary to specify this when
+    the `mapping` value is based on the same model as the queryset.
     """
-    model, field = get_model_and_field(field_props["mapping"])
+    model, field = get_model_and_field(
+        field_props["mapping_for_search_filter"] if "mapping_for_search_filter" in field_props
+        else field_props["mapping"]
+    )
 
     if field_props["datatype"] == "string":
         condition = {f"{field}__iexact": value}

--- a/chord_metadata_service/restapi/utils.py
+++ b/chord_metadata_service/restapi/utils.py
@@ -2,7 +2,7 @@ import isodate
 import datetime
 
 from collections import defaultdict, Counter
-from typing import Tuple, Mapping
+from typing import Tuple, Mapping, Generator
 from calendar import month_abbr
 
 from django.db.models import Count, F, Func, IntegerField, CharField, Case, When, Value
@@ -116,7 +116,70 @@ def iso_duration_to_years(iso_age_duration: str, unit="years"):
     return None, None
 
 
-def labelled_range_generator(field_props) -> Tuple[int, int, str]:
+def labelled_range_generator(field_props) -> Generator[Tuple[int, int, str], None, None]:
+    """
+    Returns a generator yielding floor, ceil and label value for each bin from
+    a numeric field configuration
+    """
+
+    c = field_props["config"]
+    if "bins" in c:
+        return custom_binning_generator(field_props)
+
+    return auto_binning_generator(field_props)
+
+
+def custom_binning_generator(field_props) -> Generator[Tuple[int, int, str], None, None]:
+    """
+    Generator for custom bins. It expects an array of bin boundaries (`bins` property)
+    `minimum` and `maximum` properties are optional. When absent, there is no lower/upper
+    bound and the corresponding bin limit is open ended (as in "< 5").
+    If present but equal to the closest bin boundary, there is no open ended bin.
+    If present but different from closest bin, an extra bin is added to collect
+    all values down/up to the min/max value that is set (open-ended without limit)
+    For example, given the following configuration:
+    {
+        minimum: 0,
+        bins: [2, 4, 8]
+    }
+    the first bin will be labelled "<2" and contain only values between 0-2
+    while the last bin will be labelled "≥ 8" and contain any value greater than
+    or equal to 8.
+    """
+
+    c = field_props["config"]
+    minimum = int(c["minimum"]) if "minimum" in c else None
+    maximum = int(c["maximum"]) if "maximum" in c else None
+    bins = [int(value) for value in c["bins"]]
+
+    # check prerequisites
+    # Note: it raises an error as it reflects an error in the config file
+    if maximum is not None and minimum is not None and maximum < minimum:
+        raise ValueError(f"Wrong min/max values in config: {field_props}")
+
+    if minimum is not None and minimum > bins[0]:
+        raise ValueError(f"Min value in config is greater than first bin: {field_props}")
+
+    if maximum is not None and maximum < bins[-1]:
+        raise ValueError(f"Max value in config is lower than last bin: {field_props}")
+
+    if len(bins) < 2:
+        raise ValueError(f"Error in bins value. At least 2 values required for defining a single bin: {field_props}")
+
+    # start generator
+    if minimum is None or minimum != bins[0]:
+        yield minimum, bins[0], f"< {bins[0]}"
+
+    for i in range(1, len(bins) - 2):
+        lhs = bins[i - 1]
+        rhs = bins[i]
+        yield lhs, rhs, f"{lhs}-{rhs}"
+
+    if maximum is None or maximum != bins[-1]:
+        yield bins[-1], maximum, f"≥ {bins[-1]}"
+
+
+def auto_binning_generator(field_props) -> Generator[Tuple[int, int, str], None, None]:
     """
     Note: limited to operations on integer values for simplicity
     A word of caution: when implementing handling of floating point values,
@@ -436,7 +499,11 @@ def get_range_stats(field_props):
 
     # Generate a list of When conditions that return a label for the given bin.
     # This is equivalent to an SQL CASE statement.
-    whens = [When(**{f"{field}__gte": floor},  **{f"{field}__lt": ceil}, then=Value(label))
+    whens = [When(
+                  **{f"{field}__gte": floor} if floor is not None else {},
+                  **{f"{field}__lt": ceil} if ceil is not None else {},
+                  then=Value(label)
+                 )
              for floor, ceil, label in labelled_range_generator(field_props)]
 
     query_set = model.objects\

--- a/docs/modules/public_api.rst
+++ b/docs/modules/public_api.rst
@@ -43,6 +43,7 @@ An array of:
 A dictionary, keyed by field id of:
 
 - "mapping" (string) - defines in a path like format, the mapping between the field and its object representation in the Django ORM. The first part is a reference to the model. The following is the "location" of the field relative to the model (might be nested or made accross joins). Example "individual/extra_properties/date_of_consent"
+- "mapping_for_search_filter" *optional* (string) - defines the mapping between the field and its object representation relative to the Individual model in the Django ORM for use in  counting matching indivduals. Example "individual/biosamples/experiment/experiment_type". When absent the value from the "mapping" property is used by default.
 - "title" (string) - name that is displayed to the user
 - "description" (string) - detailed description of the field, suitable for a tooltip
 - "datatype" (options number, date, string) - defines the type of field
@@ -135,6 +136,7 @@ Example of the config.json
         },
         "experiment_type": {
             "mapping": "experiment/experiment_type",
+            "mapping_for_search_filter": "individual/biosamples/experiment/experiment_type"
             "title": "Experiment Types",
             "description": "Types of experiments performed on a sample",
             "datatype": "string",

--- a/docs/modules/public_api.rst
+++ b/docs/modules/public_api.rst
@@ -50,12 +50,21 @@ A dictionary, keyed by field id of:
 
   - [datatype=number].config:
 
-    - "bin-size" (number): bins width. Due to implementation limitations, must be an integer for now.
-    - "minimum" (number): values lesser than minimum can't be queried
-    - "maximum" (number): values greater than or equal to maximum can't be queried
-    - "taper_left" (number): cutoff value for the first bin. Disabled when equals to ``minimum``
-    - "taper_right" (number): cutoff value for the last bin. Disabled when equals to ``maximum``
-    - "units" (string): unit that will be displayed to the user
+    - Config for auto-binning:
+
+      - "bin-size" (number): bins width. Due to implementation limitations, must be an integer for now.
+      - "minimum" (number): values lesser than minimum can't be queried
+      - "maximum" (number): values greater than or equal to maximum can't be queried
+      - "taper_left" (number): cutoff value for the first bin. Disabled when equals to ``minimum``
+      - "taper_right" (number): cutoff value for the last bin. Disabled when equals to ``maximum``
+      - "units" (string): unit that will be displayed to the user
+
+    - Config for custom binning:
+
+      - "bins" (list of numbers): boundaries of the bins
+      - "minimum" *optional* (number): values lesser than minimum can't be queried. When absent, no limit is applied on the minimum boundary for the first bin.
+      - "maximum" *optional* (number): values greater than or equal to maximum can't be queried. When absent, no limit is applied on the maximum boundary for the last bin.
+
 
   - [datatype=string].config:
 


### PR DESCRIPTION
## New features
- allow custom bins definition in public config for numeric fields
- allow different field mappings for overview (statistics) and search (in current Bento Public, searches return a number of individuals, so fields must be defined in relation to the Individual model)

## How to test
- Test suite should run without error
-  The example of config file has been updated in ./chord_metadata_service/example.config.json. In the context of Bento, this file can be copied in bentov2/lib/katsu/config.json which is automatically mounted in ./chord_metadata_service/config.json in the bentov2-katsu container. The container must be restarted for the changes to take properly effect. From there, it should be possible to see the expected results in Bento_public for the fields lab_test_results and experiment_types.