### PR TITLE
Features/beacon search latest

### DIFF
--- a/chord_metadata_service/chord/tests/test_api_search.py
+++ b/chord_metadata_service/chord/tests/test_api_search.py
@@ -269,7 +269,6 @@ class SearchTest(APITestCase):
 
         # TODO: Check schema?
 
-
     def test_beacon_search(self):
         # Valid search with result
         for method in POST_GET:
@@ -283,7 +282,6 @@ class SearchTest(APITestCase):
             self.assertIn(str(self.table.identifier), c["results"])
             self.assertEqual(c["results"][str(self.table.identifier)]["data_type"], DATA_TYPE_PHENOPACKET)
             self.assertEqual(self.phenopacket.id, c["results"][str(self.table.identifier)]["matches"][0]["id"])
-
 
     def test_private_table_search_1(self):
         # No body

--- a/chord_metadata_service/chord/tests/test_api_search.py
+++ b/chord_metadata_service/chord/tests/test_api_search.py
@@ -269,6 +269,22 @@ class SearchTest(APITestCase):
 
         # TODO: Check schema?
 
+
+    def test_beacon_search(self):
+        # Valid search with result
+        for method in POST_GET:
+            r = self._search_call("beacon-search", data={
+                "data_type": DATA_TYPE_PHENOPACKET,
+                "query": TEST_SEARCH_QUERY_1
+            }, method=method)
+            self.assertEqual(r.status_code, status.HTTP_200_OK)
+            c = r.json()
+
+            self.assertIn(str(self.table.identifier), c["results"])
+            self.assertEqual(c["results"][str(self.table.identifier)]["data_type"], DATA_TYPE_PHENOPACKET)
+            self.assertEqual(self.phenopacket.id, c["results"][str(self.table.identifier)]["matches"][0]["id"])
+
+
     def test_private_table_search_1(self):
         # No body
 

--- a/chord_metadata_service/chord/urls.py
+++ b/chord_metadata_service/chord/urls.py
@@ -21,6 +21,7 @@ urlpatterns = [
     path('tables/<str:table_id>/summary', views_search.chord_table_summary, name="table-summary"),
     path('tables/<str:table_id>/search', views_search.chord_public_table_search, name="public-table-search"),
     path('search', views_search.chord_search, name="search"),
+    path('beacon-search', views_search.beacon_search, name="beacon-search"),
     path('fhir-search', views_search.fhir_public_search, name="fhir-search"),
     path('private/fhir-search', views_search.fhir_private_search, name="fhir-private-search"),
     path('private/search', views_search.chord_private_search, name="private-search"),

--- a/chord_metadata_service/chord/views_search.py
+++ b/chord_metadata_service/chord/views_search.py
@@ -505,6 +505,14 @@ def chord_private_search(request):
     return search(request, internal_data=True)
 
 
+@cache_page(60 * 60 * 2)
+@api_view(["GET", "POST"])
+@permission_classes([AllowAny])
+def beacon_search(request):
+    # Equivalent to chord_private_search above, but protected by gateway only
+    return search(request, internal_data=True)
+
+
 def phenopacket_filter_results(subject_ids, htsfile_ids, disease_ids, biosample_ids,
                                phenotypicfeature_ids, phenopacket_ids):
     query = Phenopacket.objects.get_queryset()

--- a/chord_metadata_service/phenopackets/autocomplete_views.py
+++ b/chord_metadata_service/phenopackets/autocomplete_views.py
@@ -3,7 +3,7 @@ from .models import Disease, PhenotypicFeature, Biosample
 
 
 class DiseaseTermAutocomplete(autocomplete.Select2QuerySetView):
-    paginate_by = 50
+    paginate_by = 200
 
     # get_result_value return result.pk
 
@@ -27,7 +27,7 @@ class DiseaseTermAutocomplete(autocomplete.Select2QuerySetView):
 
 
 class PhenotypicFeatureTypeAutocomplete(autocomplete.Select2QuerySetView):
-    paginate_by = 50
+    paginate_by = 200
 
     def get_result_value(self, result):
         # returns phenotypic feature type ontology id
@@ -46,7 +46,7 @@ class PhenotypicFeatureTypeAutocomplete(autocomplete.Select2QuerySetView):
 
 
 class BiosampleSampledTissueAutocomplete(autocomplete.Select2QuerySetView):
-    paginate_by = 50
+    paginate_by = 200
 
     def get_result_value(self, result):
         # returns biosample sample tissue ontology id


### PR DESCRIPTION
Adds a new endpoint `/api/beacon-search` for searches forwarded from [beacon](https://github.com/bento-platform/bento_beacon). 

Beacon is a data discovery service focusing on genetic variants. [Version 2 of beacon](https://beacon-project.io/) has the ability to filter queries by clinical or other metadata, so needs the ability to query both katsu and gohan. Note that this endpoint is protected by the gateway only, similar to `/api/individuals` and other endpoints. 

Also in this pr:
- tweaked pagination limits for katsu autocomplete endpoints, which are called by beacon
- tests