### PR TITLE
fix for biosamples overcount in search results

### DIFF
--- a/chord_metadata_service/patients/api_views.py
+++ b/chord_metadata_service/patients/api_views.py
@@ -9,7 +9,7 @@ from django.utils.decorators import method_decorator
 from django.views.decorators.cache import cache_page
 from django_filters.rest_framework import DjangoFilterBackend
 from django.core.exceptions import ValidationError
-from django.db.models import Count, F
+from django.db.models import Count, F, Q
 from django.db.models.functions import Coalesce
 from django.contrib.postgres.aggregates import ArrayAgg
 from bento_lib.responses import errors
@@ -87,7 +87,7 @@ class IndividualViewSet(viewsets.ModelViewSet):
             ).annotate(
                 num_experiments=Count("biosamples__experiment"),
                 biosamples=Coalesce(
-                    ArrayAgg("biosamples__id"),
+                    ArrayAgg("biosamples__id", distinct=True, filter=Q(biosamples__id__isnull=False)),
                     []
                 )
             )


### PR DESCRIPTION
Fixes two issues with biosamples in Bento search results:

- biosamples were overcounted when multiple experiments were performed on a single sample (Redmine [#1298](https://206.12.92.46/issues/1298))
- individuals with no biosamples were mistakenly listed as having one biosample (a "null" biosample).

The same fix appears twice (there is distinct code for Bento "Advanced Search" and "Text Search").