### PR TITLE
remove containing opt. in c. vocab. fields explore

### DIFF
--- a/chord_metadata_service/chord/tests/constants.py
+++ b/chord_metadata_service/chord/tests/constants.py
@@ -248,7 +248,7 @@ TEST_SEARCH_QUERY_5 = ["#ico", ["#resolve", "phenotypic_features", "[item]", "ty
 TEST_SEARCH_QUERY_6 = ["#ico", ["#resolve", "biosamples", "[item]", "sampled_tissue", "label"],
                        "URINARY BLADDER"]
 TEST_SEARCH_QUERY_7 = ["#eq", ["#resolve", "experiment_results", "[item]", "file_format"], "VCF"]
-TEST_SEARCH_QUERY_8 = ["#ico", ["#resolve", "experiment_type"], "chromatin"]
+TEST_SEARCH_QUERY_8 = ["#eq", ["#resolve", "experiment_type"], "DNA Methylation"]
 TEST_SEARCH_QUERY_9 = ["#eq", ["#resolve", "subject", "id"], "patient:1"]
 TEST_SEARCH_QUERY_10 = ["#in", ["#resolve", "biosamples", "[item]", "id"],
                         ["#list", "biosample_id:1", "biosample_id:2"]]

--- a/chord_metadata_service/chord/tests/test_api_search.py
+++ b/chord_metadata_service/chord/tests/test_api_search.py
@@ -427,7 +427,7 @@ class SearchTest(APITestCase):
             self.assertIn(str(self.t_exp.identifier), c["results"])
             self.assertEqual(c["results"][str(self.t_exp.identifier)]["data_type"], DATA_TYPE_EXPERIMENT)
             self.assertEqual(c["results"][str(self.t_exp.identifier)]["matches"][0]["experiment_type"],
-                             "Chromatin Accessibility")
+                             "DNA Methylation")
 
     # TODO table search fr experiments
 

--- a/chord_metadata_service/experiments/search_schemas.py
+++ b/chord_metadata_service/experiments/search_schemas.py
@@ -27,7 +27,7 @@ EXPERIMENT_RESULT_SEARCH_SCHEMA = tag_schema_with_search_properties(schemas.EXPE
             "search": search_optional_eq(4)
         },
         "usage": {
-            "search": search_optional_str(5)
+            "search": search_optional_eq(5)
         },
         "genome_assembly_id": {
             "search": search_optional_eq(6)
@@ -79,21 +79,21 @@ EXPERIMENT_SEARCH_SCHEMA = tag_schema_with_search_properties(schemas.EXPERIMENT_
             "search": {"order": 2, "database": {"type": "array"}}
         },
         "experiment_type": {
-            "search": search_optional_str(3),
+            "search": search_optional_eq(3),
         },
         "experiment_ontology": {
             "items": ONTOLOGY_SEARCH_SCHEMA,  # TODO: Specific ontology?
             "search": {"order": 4, "database": {"type": "jsonb"}}
         },
         "molecule": {
-            "search": search_optional_str(5),
+            "search": search_optional_eq(5),
         },
         "molecule_ontology": {
             "items": ONTOLOGY_SEARCH_SCHEMA,  # TODO: Specific ontology?
             "search": {"order": 6, "database": {"type": "jsonb"}}
         },
         "library_strategy": {
-            "search": search_optional_str(7),
+            "search": search_optional_eq(7),
         },
         "biosample": {
             "search": merge_schema_dictionaries(
@@ -105,16 +105,16 @@ EXPERIMENT_SEARCH_SCHEMA = tag_schema_with_search_properties(schemas.EXPERIMENT_
             "search": search_optional_str(9),
         },
         "study_type": {
-            "search": search_optional_str(10),
+            "search": search_optional_eq(10),
         },
         "library_source": {
-            "search": search_optional_str(11),
+            "search": search_optional_eq(11),
         },
         "library_selection": {
-            "search": search_optional_str(12),
+            "search": search_optional_eq(12),
         },
         "library_layout": {
-            "search": search_optional_str(13),
+            "search": search_optional_eq(13),
         },
         # query example: ["#ico", ["#resolve", "instrument", "model"], "Illumina"]
         "instrument": merge_schema_dictionaries(

--- a/chord_metadata_service/experiments/tests/constants.py
+++ b/chord_metadata_service/experiments/tests/constants.py
@@ -2,7 +2,7 @@ def valid_experiment(biosample, instrument=None, table=None, num_experiment=1):
     return {
         "id": f"experiment:{num_experiment}",
         "study_type": "Whole genome Sequencing",
-        "experiment_type": "Chromatin Accessibility",
+        "experiment_type": "DNA Methylation",
         "experiment_ontology": [{"id": "ontology:1", "label": "Ontology term 1"}],
         "molecule": "total RNA",
         "molecule_ontology": [{"id": "ontology:1", "label": "Ontology term 1"}],

--- a/chord_metadata_service/experiments/tests/test_models.py
+++ b/chord_metadata_service/experiments/tests/test_models.py
@@ -33,7 +33,7 @@ class ExperimentTest(TestCase):
             serializers.ValidationError,
             self.create,
             library_strategy="Bisulfite-Seq",
-            experiment_type="Chromatin Accessibility",
+            experiment_type="DNA Methylation",
             experiment_ontology=["invalid_value"],
             biosample=self.biosample
         )
@@ -50,7 +50,7 @@ class ExperimentTest(TestCase):
             serializers.ValidationError,
             self.create,
             library_strategy="Bisulfite-Seq",
-            experiment_type="Chromatin Accessibility",
+            experiment_type="DNA Methylation",
             molecule_ontology=[{"id": "some_id"}],
             biosample=self.biosample
         )
@@ -60,7 +60,7 @@ class ExperimentTest(TestCase):
             serializers.ValidationError,
             self.create,
             library_strategy="Bisulfite-Seq",
-            experiment_type="Chromatin Accessibility",
+            experiment_type="DNA Methylation",
             extra_properties={"some_field": "value", "invalid_value": 42},
             biosample=self.biosample
         )
@@ -70,7 +70,7 @@ class ExperimentTest(TestCase):
             ValidationError,
             self.create,
             library_strategy="Bisulfite-Seq",
-            experiment_type="Chromatin Accessibility"
+            experiment_type="DNA Methylation"
         )
 
 

--- a/chord_metadata_service/restapi/tests/test_api.py
+++ b/chord_metadata_service/restapi/tests/test_api.py
@@ -88,7 +88,7 @@ class OverviewTest(APITestCase):
         self.assertEqual(response_obj['data_type_specific']['experiments']['count'], 2)
         self.assertEqual(response_obj['data_type_specific']['experiments']['study_type']['Whole genome Sequencing'], 2)
         self.assertEqual(
-            response_obj['data_type_specific']['experiments']['experiment_type']['Chromatin Accessibility'], 2
+            response_obj['data_type_specific']['experiments']['experiment_type']['DNA Methylation'], 2
         )
         self.assertEqual(response_obj['data_type_specific']['experiments']['molecule']['total RNA'], 2)
         self.assertEqual(response_obj['data_type_specific']['experiments']['library_strategy']['Bisulfite-Seq'], 2)


### PR DESCRIPTION
Remove the "containig" option in explore  for experiments with  controlled vocabularies  in experiments schemas. Explorer - fields with controlled vocabulary now only have "=" as an operator
fields:  file_format, usage, study_type, experiment_type, experiment_ontology, library_strategy, library_source, library_selection, library_layout. 
