### PR TITLE
remove enum from experiments usage property

### DIFF
--- a/chord_metadata_service/experiments/schemas.py
+++ b/chord_metadata_service/experiments/schemas.py
@@ -36,8 +36,7 @@ EXPERIMENT_RESULT_SCHEMA = tag_ids_and_describe({
             "enum": ["Raw data", "Derived data"]
         },
         "usage": {
-            "type": "string",
-            "enum": ["Visualized", "Downloaded"]
+            "type": "string"
         },
         "creation_date": {
             "type": "string"

--- a/chord_metadata_service/experiments/search_schemas.py
+++ b/chord_metadata_service/experiments/search_schemas.py
@@ -27,7 +27,7 @@ EXPERIMENT_RESULT_SEARCH_SCHEMA = tag_schema_with_search_properties(schemas.EXPE
             "search": search_optional_eq(4)
         },
         "usage": {
-            "search": search_optional_eq(5)
+            "search": search_optional_str(5)
         },
         "genome_assembly_id": {
             "search": search_optional_eq(6)


### PR DESCRIPTION
Remove controlled vocabulary from experiments results "usage" field. 