### PR TITLE
Bugfix/bento public missing

### DIFF
--- a/chord_metadata_service/patients/api_views.py
+++ b/chord_metadata_service/patients/api_views.py
@@ -194,11 +194,13 @@ class PublicListIndividuals(APIView):
 
         tissues_count, sampled_tissues = get_queryset_stats(
             filtered_qs,
-            "phenopackets__biosamples__sampled_tissue__label"
+            "phenopackets__biosamples__sampled_tissue__label",
+            censor_small_categories=False
         )
         experiments_count, experiment_type = get_queryset_stats(
             filtered_qs,
-            "phenopackets__biosamples__experiment__experiment_type"
+            "phenopackets__biosamples__experiment__experiment_type",
+            censor_small_categories=False
         )
         return Response({
             "count": filtered_qs.count(),

--- a/chord_metadata_service/patients/api_views.py
+++ b/chord_metadata_service/patients/api_views.py
@@ -31,7 +31,6 @@ from chord_metadata_service.restapi.pagination import LargeResultsSetPagination,
 from chord_metadata_service.restapi.utils import (
     get_field_options,
     filter_queryset_field_value,
-    get_queryset_stats,
     biosample_tissue_stats,
     experiment_type_stats
 )

--- a/chord_metadata_service/patients/api_views.py
+++ b/chord_metadata_service/patients/api_views.py
@@ -31,7 +31,9 @@ from chord_metadata_service.restapi.pagination import LargeResultsSetPagination,
 from chord_metadata_service.restapi.utils import (
     get_field_options,
     filter_queryset_field_value,
-    get_queryset_stats
+    get_queryset_stats,
+    biosample_tissue_stats,
+    experiment_type_stats
 )
 from chord_metadata_service.restapi.negociation import FormatInPostContentNegotiation
 from drf_spectacular.utils import extend_schema, inline_serializer
@@ -192,16 +194,9 @@ class PublicListIndividuals(APIView):
         if filtered_qs.count() <= settings.CONFIG_PUBLIC["rules"]["count_threshold"]:
             return Response(settings.INSUFFICIENT_DATA_AVAILABLE)
 
-        tissues_count, sampled_tissues = get_queryset_stats(
-            filtered_qs,
-            "phenopackets__biosamples__sampled_tissue__label",
-            censor_small_categories=False
-        )
-        experiments_count, experiment_type = get_queryset_stats(
-            filtered_qs,
-            "phenopackets__biosamples__experiment__experiment_type",
-            censor_small_categories=False
-        )
+        tissues_count, sampled_tissues = biosample_tissue_stats(filtered_qs)
+        experiments_count, experiment_types = experiment_type_stats(filtered_qs)
+
         return Response({
             "count": filtered_qs.count(),
             "biosamples": {
@@ -210,6 +205,6 @@ class PublicListIndividuals(APIView):
             },
             "experiments": {
                 "count": experiments_count,
-                "experiment_type": experiment_type
+                "experiment_type": experiment_types
             }
         })

--- a/chord_metadata_service/patients/tests/test_api.py
+++ b/chord_metadata_service/patients/tests/test_api.py
@@ -662,7 +662,7 @@ class PublicAgeRangeFilteringIndividualsTest(APITestCase):
 class PublicFilteringBiosampleAndExperimentStatsTest(APITestCase):
     """ Test for stats returned by api/public GET """
 
-    response_threshold = 1
+    response_threshold = 0
     num_individuals_without_phenopackets = 30
 
     def setUp(self) -> None:

--- a/chord_metadata_service/patients/tests/test_api.py
+++ b/chord_metadata_service/patients/tests/test_api.py
@@ -13,8 +13,7 @@ from chord_metadata_service.restapi.tests.constants import CONFIG_PUBLIC_TEST, C
 from chord_metadata_service.restapi.utils import iso_duration_to_years
 from chord_metadata_service.phenopackets.tests import constants as ph_c
 from chord_metadata_service.phenopackets import models as ph_m
-from chord_metadata_service.experiments.tests.constants import valid_experiment
-from chord_metadata_service.phenopackets.models import Biosample, Procedure, Biosample, MetaData, Phenopacket, Procedure
+from chord_metadata_service.phenopackets.models import Biosample, Procedure, MetaData, Phenopacket
 from chord_metadata_service.experiments.models import Experiment, ExperimentResult, Instrument
 from chord_metadata_service.experiments.tests import constants as exp_c
 from chord_metadata_service.chord.models import Project, Dataset, TableOwnership, Table

--- a/chord_metadata_service/restapi/utils.py
+++ b/chord_metadata_service/restapi/utils.py
@@ -227,7 +227,7 @@ def monthly_generator(start: str, end: str) -> Tuple[int, int]:
     [end_year, end_month] = [int(k) for k in end.split("-")]
     last_month_nb = (end_year - start_year) * 12 + end_month
     for month_nb in range(start_month, last_month_nb):
-        year = start_year + month_nb // 12
+        year = start_year + (month_nb - 1) // 12
         month = month_nb % 12 or 12
         yield year, month
 
@@ -486,11 +486,11 @@ def get_range_stats(field_props):
     # Generate a list of When conditions that return a label for the given bin.
     # This is equivalent to an SQL CASE statement.
     whens = [When(
-                  **{f"{field}__gte": floor} if floor is not None else {},
-                  **{f"{field}__lt": ceil} if ceil is not None else {},
-                  then=Value(label)
-                 )
-             for floor, ceil, label in labelled_range_generator(field_props)]
+        **{f"{field}__gte": floor} if floor is not None else {},
+        **{f"{field}__lt": ceil} if ceil is not None else {},
+        then=Value(label)
+    )
+        for floor, ceil, label in labelled_range_generator(field_props)]
 
     query_set = model.objects\
         .values(label=Case(*whens, default=Value("missing"), output_field=CharField()))\

--- a/chord_metadata_service/restapi/utils.py
+++ b/chord_metadata_service/restapi/utils.py
@@ -351,27 +351,6 @@ def get_age_numeric_binned(individual_queryset, bin_size):
     return individuals_age
 
 
-def get_queryset_stats(queryset, field, censor_small_categories=True):
-    """
-    Fetches public statistics for a field within a given queryset. This function
-    is used to compute statistics after filtering has been applied.
-    Defaults to applying a cutoff for categories under the threshold
-    """
-    stats = queryset_stats_for_field(queryset, field, add_missing=True)
-    threshold = settings.CONFIG_PUBLIC["rules"]["count_threshold"]
-    bins = []
-    total = 0
-    for key, value in stats.items():
-        bins.append({
-            "label": key,
-            "value": value if not (value < threshold and censor_small_categories) else 0
-        })
-        total += value
-    if total <= threshold:
-        total = 0
-    return total, bins
-
-
 def get_categorical_stats(field_props):
     """
     Fetches statistics for a given categorical field and apply privacy policies

--- a/chord_metadata_service/restapi/utils.py
+++ b/chord_metadata_service/restapi/utils.py
@@ -625,8 +625,8 @@ def bento_public_format_count_and_stats_list(annotated_queryset):
     for q in annotated_queryset:
         label = q["label"]
         value = int(q["value"])
+        total += value
         if label is not None:
-            total += value
             stats_list.append({"label": label, "value": value})
         elif value > 0:
             stats_list.append({"missing": value})

--- a/chord_metadata_service/restapi/utils.py
+++ b/chord_metadata_service/restapi/utils.py
@@ -350,11 +350,11 @@ def get_age_numeric_binned(individual_queryset, bin_size):
     return individuals_age
 
 
-def get_queryset_stats(queryset, field):
+def get_queryset_stats(queryset, field, censor_small_categories=True):
     """
     Fetches public statistics for a field within a given queryset. This function
     is used to compute statistics after filtering has been applied.
-    A cutoff is applied to all counts to avoid leaking too small sets of results.
+    Optionally apply a cutoff for categories under the threshold
     """
     stats = queryset_stats_for_field(queryset, field, add_missing=True)
     threshold = settings.CONFIG_PUBLIC["rules"]["count_threshold"]
@@ -363,7 +363,7 @@ def get_queryset_stats(queryset, field):
     for key, value in stats.items():
         bins.append({
             "label": key,
-            "value": value if value > threshold else 0
+            "value": value if not (value < threshold and censor_small_categories) else 0
         })
         total += value
     if total <= threshold:

--- a/chord_metadata_service/restapi/utils.py
+++ b/chord_metadata_service/restapi/utils.py
@@ -355,7 +355,7 @@ def get_queryset_stats(queryset, field, censor_small_categories=True):
     """
     Fetches public statistics for a field within a given queryset. This function
     is used to compute statistics after filtering has been applied.
-    Optionally apply a cutoff for categories under the threshold
+    Defaults to applying a cutoff for categories under the threshold
     """
     stats = queryset_stats_for_field(queryset, field, add_missing=True)
     threshold = settings.CONFIG_PUBLIC["rules"]["count_threshold"]

--- a/chord_metadata_service/restapi/utils.py
+++ b/chord_metadata_service/restapi/utils.py
@@ -607,7 +607,5 @@ def bento_public_format_count_and_stats_list(annotated_queryset):
         total += value
         if label is not None:
             stats_list.append({"label": label, "value": value})
-        elif value > 0:
-            stats_list.append({"missing": value})
 
     return total, stats_list

--- a/chord_metadata_service/restapi/utils.py
+++ b/chord_metadata_service/restapi/utils.py
@@ -226,7 +226,7 @@ def monthly_generator(start: str, end: str) -> Tuple[int, int]:
     [start_year, start_month] = [int(k) for k in start.split("-")]
     [end_year, end_month] = [int(k) for k in end.split("-")]
     last_month_nb = (end_year - start_year) * 12 + end_month
-    for month_nb in range(start_month, last_month_nb):
+    for month_nb in range(start_month, last_month_nb + 1):
         year = start_year + (month_nb - 1) // 12
         month = month_nb % 12 or 12
         yield year, month
@@ -486,11 +486,11 @@ def get_range_stats(field_props):
     # Generate a list of When conditions that return a label for the given bin.
     # This is equivalent to an SQL CASE statement.
     whens = [When(
-        **{f"{field}__gte": floor} if floor is not None else {},
-        **{f"{field}__lt": ceil} if ceil is not None else {},
-        then=Value(label)
-    )
-        for floor, ceil, label in labelled_range_generator(field_props)]
+                  **{f"{field}__gte": floor} if floor is not None else {},
+                  **{f"{field}__lt": ceil} if ceil is not None else {},
+                  then=Value(label)
+                 )
+             for floor, ceil, label in labelled_range_generator(field_props)]
 
     query_set = model.objects\
         .values(label=Case(*whens, default=Value("missing"), output_field=CharField()))\


### PR DESCRIPTION
This fixes several issues with the response from `api/public` and `api/public_overview` used by bento_public.

Previously, `api/public` returned only a count of individuals. The current version returns a richer results set, including; 
- count of biosamples
- count of experiments 
- array of counts for `sampled_tissue` in biosamples
- array of counts for `experiment_type` in experiment 

In many cases, some or all of these values were incorrect. Changes include: 

- removing censorship in counts for `sampled_tissue` and `experiment_type` in searches. Censorship of searches is all-or-nothing by count of individuals, not line-by-line in breakdown of statistics. (However, censorship still remains at the category level for overview statistics). 
- correcting the handling of missing values in querysets (this affects both overview and search)
- hardcoding queries for `sampled_tissue` and `experiment_type` to handle the statistics returned by `api/public`.
- fix for off-by-one error in generation of month labels (Dec 2021 was placed immediately before January 2021)