### PR TITLE
Fixes/view summary response

### DIFF
--- a/chord_metadata_service/restapi/api_views.py
+++ b/chord_metadata_service/restapi/api_views.py
@@ -154,11 +154,14 @@ def search_overview(request):
 
     individuals_count = len(individual_id)
     biosamples_count = queryset.values("phenopackets__biosamples__id").count()
-    experiments_count = queryset.values("phenopackets__biosamples__experiment__id").count()
 
     # Sex related fields stats are precomputed here and post processed later
     # to include missing values inferred from the schema
     individuals_sex = queryset_stats_for_field(queryset, "sex")
+
+    # several obvious approaches to experiment counts give incorrect answers
+    experiment_types = queryset_stats_for_field(queryset, "phenopackets__biosamples__experiment__experiment_type")
+    experiments_count = sum(experiment_types.values())
 
     r = {
         "biosamples": {
@@ -182,10 +185,7 @@ def search_overview(request):
         },
         "experiments": {
             "count": experiments_count,
-            "experiment_type": queryset_stats_for_field(
-                queryset,
-                "phenopackets__biosamples__experiment__experiment_type"
-            ),
+            "experiment_type": experiment_types,
         },
     }
     return Response(r)

--- a/chord_metadata_service/restapi/api_views.py
+++ b/chord_metadata_service/restapi/api_views.py
@@ -155,6 +155,7 @@ def search_overview(request):
     if len(individual_id) > 0:
         queryset = queryset.filter(id__in=individual_id)
 
+    individuals_count = len(individual_id)
     biosamples_count = queryset.values("phenopackets__biosamples__id").count()
     experiments_count = queryset.values("phenopackets__biosamples__experiment__id").count()
 
@@ -175,6 +176,7 @@ def search_overview(request):
             "term": queryset_stats_for_field(queryset, "phenopackets__diseases__term__label"),
         },
         "individuals": {
+            "count": individuals_count,
             "sex": {k: individuals_sex.get(k, 0) for k in (s[0] for s in pheno_models.Individual.SEX)},
             "age": get_age_numeric_binned(queryset, OVERVIEW_AGE_BIN_SIZE),
         },

--- a/chord_metadata_service/restapi/api_views.py
+++ b/chord_metadata_service/restapi/api_views.py
@@ -150,10 +150,7 @@ def search_overview(request):
         - id: a list of patient ids
     """
     individual_id = request.GET.getlist("id") if request.method == "GET" else request.data.get("id", [])
-
-    queryset = patients_models.Individual.objects.all()
-    if len(individual_id) > 0:
-        queryset = queryset.filter(id__in=individual_id)
+    queryset = patients_models.Individual.objects.all().filter(id__in=individual_id)
 
     individuals_count = len(individual_id)
     biosamples_count = queryset.values("phenopackets__biosamples__id").count()


### PR DESCRIPTION
Fixes to the `api/search_overview` endpoint, which returns summary statistics when given an array of individual ids. This is part of the reimplementation of bento_web's "View Summary" feature (Redmine [1259](https://206.12.92.46/issues/1259), [1350](https://206.12.92.46/issues/1350))

- add count of individuals
- remove unclear behaviour when no ids given
- fixes to experiment counts

Experiment counts were consistently unreliable in the previous implementation, and correct-looking solutions, such as 

`experiments_count = queryset.values("phenopackets__biosamples__experiment__id").count()
`
   or 
`experiments_count = queryset.values("phenopackets__biosamples__experiment__id").distinct().count()
`

fail to give the correct answer. Well-crafted custom Django queries can give better answers, but inconsistencies in some of the current data (such as the same biosample repeated across clearly distinct individuals) further complicate the issue of which answer is "correct". For now the total count of experiments is computed by summing the values from `experiment_type`, which is a required field. 


