### PR TITLE
Improve error handling when ingestion schema validation fails

### DIFF
--- a/chord_metadata_service/chord/ingest/experiments.py
+++ b/chord_metadata_service/chord/ingest/experiments.py
@@ -17,6 +17,10 @@ from .schema import schema_validation
 from .utils import get_output_or_raise, workflow_file_output_to_path
 
 __all__ = [
+    "create_instrument",
+    "create_experiment_result",
+    "validate_experiment",
+    "ingest_experiment",
     "ingest_experiments_workflow",
     "ingest_maf_derived_from_vcf_workflow",
 ]

--- a/chord_metadata_service/chord/ingest/experiments.py
+++ b/chord_metadata_service/chord/ingest/experiments.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import json
 import uuid
 

--- a/chord_metadata_service/chord/ingest/phenopackets.py
+++ b/chord_metadata_service/chord/ingest/phenopackets.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import json
 import uuid
 

--- a/chord_metadata_service/chord/ingest/phenopackets.py
+++ b/chord_metadata_service/chord/ingest/phenopackets.py
@@ -9,6 +9,7 @@ from chord_metadata_service.phenopackets import models as pm
 from chord_metadata_service.phenopackets.schemas import PHENOPACKET_SCHEMA
 from chord_metadata_service.restapi.utils import iso_duration_to_years
 
+from .exceptions import IngestError
 from .logger import logger
 from .resources import ingest_resource
 from .schema import schema_validation
@@ -53,13 +54,16 @@ def get_or_create_phenotypic_feature(pf):
     return pf_obj
 
 
-def ingest_phenopacket(phenopacket_data: Dict[str, Any], table_id: str) -> Optional[pm.Phenopacket]:
+def ingest_phenopacket(phenopacket_data: Dict[str, Any], table_id: str, idx: Optional[int] = None) -> pm.Phenopacket:
     """Ingests a single phenopacket."""
 
     # validate phenopackets data against phenopacket schema
     validation = schema_validation(phenopacket_data, PHENOPACKET_SCHEMA)
     if not validation:
-        return
+        # TODO: Report more precise errors
+        raise IngestError(
+            f"Failed schema validation for phenopacket{(' ' + str(idx)) if idx is not None else ''} "
+            f"(check Katsu logs for more information)")
 
     new_phenopacket_id = phenopacket_data.get("id", str(uuid.uuid4()))
 

--- a/chord_metadata_service/chord/ingest/phenopackets.py
+++ b/chord_metadata_service/chord/ingest/phenopackets.py
@@ -17,7 +17,7 @@ from .resources import ingest_resource
 from .schema import schema_validation
 from .utils import get_output_or_raise, map_if_list, query_and_check_nulls, workflow_file_output_to_path
 
-from typing import Any, Dict, Optional, Union
+from typing import Any, Optional, Union
 
 
 def get_or_create_phenotypic_feature(pf: dict) -> pm.PhenotypicFeature:
@@ -56,7 +56,7 @@ def get_or_create_phenotypic_feature(pf: dict) -> pm.PhenotypicFeature:
     return pf_obj
 
 
-def validate_phenopacket(phenopacket_data: Dict[str, Any], idx: Optional[int] = None) -> None:
+def validate_phenopacket(phenopacket_data: dict[str, Any], idx: Optional[int] = None) -> None:
     # Validate phenopacket data against phenopackets schema.
     validation = schema_validation(phenopacket_data, PHENOPACKET_SCHEMA)
     if not validation:
@@ -66,7 +66,7 @@ def validate_phenopacket(phenopacket_data: Dict[str, Any], idx: Optional[int] = 
             f"(check Katsu logs for more information)")
 
 
-def ingest_phenopacket(phenopacket_data: Dict[str, Any], table_id: str, validate: bool = True,
+def ingest_phenopacket(phenopacket_data: dict[str, Any], table_id: str, validate: bool = True,
                        idx: Optional[int] = None) -> pm.Phenopacket:
     """Ingests a single phenopacket."""
 
@@ -87,7 +87,7 @@ def ingest_phenopacket(phenopacket_data: Dict[str, Any], table_id: str, validate
     meta_data = phenopacket_data["meta_data"]
 
     if subject:
-        extra_properties: Dict[str, Any] = subject.get("extra_properties", {})
+        extra_properties: dict[str, Any] = subject.get("extra_properties", {})
 
         # Pre-process subject data:    ---------------------------------------------------------------------------------
 

--- a/chord_metadata_service/chord/ingest/utils.py
+++ b/chord_metadata_service/chord/ingest/utils.py
@@ -28,9 +28,12 @@ HTTPS_URI_SCHEME = "https"
 WINDOWS_DRIVE_SCHEME = re.compile(r"^[a-zA-Z]$")
 
 
-def map_if_list(fn: Callable, data: Any, *args) -> Any:
+def map_if_list(fn: Callable, data: Any, *args, **kwargs) -> Any:
     # TODO: Any sequence?
-    return [fn(d, *args, idx=idx) for idx, d in enumerate(data)] if isinstance(data, list) else fn(data, *args)
+    return (
+        [fn(d, *args, idx=idx, **kwargs) for idx, d in enumerate(data)] if isinstance(data, list)
+        else fn(data, *args, **kwargs)
+    )
 
 
 def get_output_or_raise(workflow_outputs, key):

--- a/chord_metadata_service/chord/ingest/utils.py
+++ b/chord_metadata_service/chord/ingest/utils.py
@@ -30,7 +30,7 @@ WINDOWS_DRIVE_SCHEME = re.compile(r"^[a-zA-Z]$")
 
 def map_if_list(fn: Callable, data: Any, *args) -> Any:
     # TODO: Any sequence?
-    return [fn(d, *args) for d in data] if isinstance(data, list) else fn(data, *args)
+    return [fn(d, *args, idx=idx) for idx, d in enumerate(data)] if isinstance(data, list) else fn(data, *args)
 
 
 def get_output_or_raise(workflow_outputs, key):

--- a/chord_metadata_service/chord/ingest/utils.py
+++ b/chord_metadata_service/chord/ingest/utils.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import contextlib
 import os
 import re

--- a/chord_metadata_service/chord/views_ingest.py
+++ b/chord_metadata_service/chord/views_ingest.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import json
 import logging
 import os

--- a/chord_metadata_service/mcode/mcode_ingest.py
+++ b/chord_metadata_service/mcode/mcode_ingest.py
@@ -4,6 +4,8 @@ from chord_metadata_service.phenopackets.models import Gene
 from . import models as m
 from django.utils import timezone
 
+from typing import Optional
+
 logger = logging.getLogger("mcode_ingest")
 logger.setLevel(logging.INFO)
 
@@ -15,7 +17,7 @@ def _logger_message(created, obj):
         logger.info(f"Existing {obj.__class__.__name__} {obj.id} retrieved")
 
 
-def ingest_mcodepacket(mcodepacket_data, table_id):
+def ingest_mcodepacket(mcodepacket_data, table_id, idx: Optional[int] = None):
     """ Ingests a single mcodepacket in mcode app and patients' metadata into patients app."""
 
     new_mcodepacket = {"id": mcodepacket_data["id"]}
@@ -274,7 +276,7 @@ def ingest_mcodepacket(mcodepacket_data, table_id):
         updated=timezone.now()
     )
     mcodepacket.save()
-    logger.info(f"New Mcodepacket {mcodepacket.id} created")
+    logger.info(f"New Mcodepacket {mcodepacket.id} created (idx={idx})")
     if crprocedures:
         mcodepacket.cancer_related_procedures.set(crprocedures)
     if medication_statements:


### PR DESCRIPTION
Here, the issue was that any failing schema checks were discarded instead of throwing an error.
I also decided to move the checks up before trying to create any objects.