### PR TITLE
Fix null individual_id in subject-associated biosamples; add logging for individuals public query endpoint

### DIFF
--- a/chord_metadata_service/chord/ingest/phenopackets.py
+++ b/chord_metadata_service/chord/ingest/phenopackets.py
@@ -223,11 +223,11 @@ def ingest_phenopacket(phenopacket_data: dict[str, Any], table_id: str, validate
 
     # Pre-process biosamples; historically (<2.17.3) we were running into issues because a missing individual_id in
     # the biosample meant it would be left as None rather than properly associated with a specified subject.
-    #   - Here, we tag the biosample with the subject's ID if a subject is specified AND no individual_id is already
-    #     specified on the biosample.
+    #   - Here, we tag the biosample with the subject's ID if a subject is specified, since the Phenopacket spec
+    #     explicitly says of the biosamples field:
+    #       "This field describes samples that have been derived from the patient who is the object of the Phenopacket"
     biosamples = [
-        {**bs, "individual_id": subject["id"]}
-        if subject and "individual_id" not in bs else bs
+        {**bs, "individual_id": subject["id"]} if subject else bs
         for bs in phenopacket_data.get("biosamples", [])
     ]
 

--- a/chord_metadata_service/chord/ingest/phenopackets.py
+++ b/chord_metadata_service/chord/ingest/phenopackets.py
@@ -217,8 +217,21 @@ def ingest_phenopacket(phenopacket_data: dict[str, Any], table_id: str, validate
 
     new_phenopacket_id = phenopacket_data.get("id", str(uuid.uuid4()))
 
+    subject = phenopacket_data.get("subject")
+
     phenotypic_features = phenopacket_data.get("phenotypic_features", [])
-    biosamples = phenopacket_data.get("biosamples", [])
+
+    # Pre-process biosamples; historically (<2.17.3) we were running into issues because a missing individual_id in
+    # the biosample meant it would be left as None rather than properly associated with a specified subject.
+    #   - Here, we tag the biosample with the subject's ID if a subject is specified AND no individual_id is already
+    #     specified on the biosample.
+    biosamples = [
+        {**bs, "individual_id": subject["id"]}
+        if subject and "individual_id" not in bs else bs
+        for bs in phenopacket_data.get("biosamples", [])
+    ]
+
+    # Pull other fields out of the phenopacket input
     genes = phenopacket_data.get("genes", [])
     diseases = phenopacket_data.get("diseases", [])
     hts_files = phenopacket_data.get("hts_files", [])
@@ -229,7 +242,7 @@ def ingest_phenopacket(phenopacket_data: dict[str, Any], table_id: str, validate
     # - or, if it already exists, *update* the extra properties if needed.
     #   This is one of the few cases of 'updating' something that exists in Katsu.
     subject_obj: Optional[pm.Individual] = None
-    if subject := phenopacket_data.get("subject"):  # we have a dictionary of subject data in the phenopacket
+    if subject:  # we have a dictionary of subject data in the phenopacket
         subject_obj = update_or_create_subject(subject)
 
     # Get or create all phenotypic features in the phenopacket

--- a/chord_metadata_service/chord/tests/example_phenopacket.json
+++ b/chord_metadata_service/chord/tests/example_phenopacket.json
@@ -122,7 +122,6 @@
         },
         {
             "id": "sample2",
-            "individual_id": "patient1",
             "description": "",
             "sampled_tissue": {
                 "id": "UBERON:0002367",
@@ -182,7 +181,6 @@
         },
         {
             "id": "sample4",
-            "individual_id": "patient1",
             "description": "",
             "sampled_tissue": {
                 "id": "UBERON:0001222",
@@ -208,7 +206,6 @@
         },
         {
             "id": "sample5",
-            "individual_id": "patient1",
             "description": "",
             "sampled_tissue": {
                 "id": "UBERON:0015876",

--- a/chord_metadata_service/chord/tests/test_export_cbio.py
+++ b/chord_metadata_service/chord/tests/test_export_cbio.py
@@ -169,8 +169,7 @@ class ExportCBioTest(TestCase):
                 break
 
     def test_export_cbio_sample_data(self):
-        samples = pm.Biosample.objects.filter(phenopacket=self.p)\
-            .annotate(phenopacket_subject_id=F("phenopacket__subject"))
+        samples = pm.Biosample.objects.filter(phenopacket=self.p)
 
         with io.StringIO() as output:
             exp.sample_export(samples, output)

--- a/chord_metadata_service/chord/tests/test_ingest.py
+++ b/chord_metadata_service/chord/tests/test_ingest.py
@@ -153,6 +153,12 @@ class IngestTest(TestCase):
 
         biosamples = list(p.biosamples.all().order_by("id"))
         self.assertEqual(len(biosamples), 5)
+
+        # Make sure biosamples are properly associated with phenopacket subject
+        #  - Some test biosamples exclude individual_id; these should be properly associated too
+        for bs in biosamples:
+            self.assertEqual(bs.individual_id, p.subject.id)
+
         # TODO: More
 
     def test_reingesting_updating_phenopackets_json(self):

--- a/chord_metadata_service/metadata/settings.py
+++ b/chord_metadata_service/metadata/settings.py
@@ -42,6 +42,8 @@ DEBUG = os.environ.get(
 ).lower() == "true"
 logging.info(f"DEBUG: {DEBUG}")
 
+LOG_LEVEL = os.environ.get("KATSU_LOG_LEVEL", "DEBUG" if DEBUG else "INFO").upper()
+
 
 # CHORD-specific settings
 
@@ -199,7 +201,7 @@ LOGGING = {
     },
     'loggers': {
         '': {
-            'level': 'DEBUG' if DEBUG else 'INFO',
+            'level': LOG_LEVEL,
             'handlers': ['console'],
         },
     },

--- a/chord_metadata_service/package.cfg
+++ b/chord_metadata_service/package.cfg
@@ -1,4 +1,4 @@
 [package]
 name = katsu
-version = 2.17.2
+version = 2.17.3
 authors = Ksenia Zaytseva, David Lougheed, Simon Chénard, Romain Grégoire, Paul Pillot, Son Chau

--- a/chord_metadata_service/restapi/pagination.py
+++ b/chord_metadata_service/restapi/pagination.py
@@ -5,6 +5,7 @@ from urllib.parse import urljoin
 
 __all__ = [
     "LargeResultsSetPagination",
+    "BatchResultsSetPagination",
 ]
 
 

--- a/chord_metadata_service/restapi/utils.py
+++ b/chord_metadata_service/restapi/utils.py
@@ -14,6 +14,7 @@ from django.conf import settings
 
 from chord_metadata_service.phenopackets import models as pheno_models
 from chord_metadata_service.experiments import models as experiments_models
+from chord_metadata_service.logger import logger
 
 
 LENGTH_Y_M = 4 + 1 + 2  # dates stored as yyyy-mm-dd
@@ -639,6 +640,8 @@ def filter_queryset_field_value(qs, field_props, value: str):
         condition = {f"{field}__startswith": val}
     else:
         raise NotImplementedError()
+
+    logger.debug(f"Filtering {model}.{field} with {condition}")
 
     return qs.filter(**condition)
 


### PR DESCRIPTION
* feat: user-specifiable log level
* chore: add logging for individual public query endpoint
* fix: non-present `individual_id` in biosample ingest documents resulting in biosamples not being associated correctly with phenopacket subjects 