### PR TITLE
Beacon search endpoint

### DIFF
--- a/chord_metadata_service/patients/api_views.py
+++ b/chord_metadata_service/patients/api_views.py
@@ -258,15 +258,14 @@ class BeaconListIndividuals(APIView):
 
     def get(self, request, *args, **kwargs):
         if not settings.CONFIG_PUBLIC:
-            return Response(settings.NO_PUBLIC_DATA_AVAILABLE)
+            return Response(settings.NO_PUBLIC_DATA_AVAILABLE, status=400)
 
         base_qs = Individual.objects.all()
         try:
             filtered_qs = self.filter_queryset(base_qs)
         except ValidationError as e:
             return Response(errors.bad_request_error(
-                *(e.error_list if hasattr(e, "error_list") else e.error_dict.items()),
-            ))
+                *(e.error_list if hasattr(e, "error_list") else e.error_dict.items())), status=400)
 
         tissues_count, sampled_tissues = biosample_tissue_stats(filtered_qs)
         experiments_count, experiment_types = experiment_type_stats(filtered_qs)

--- a/chord_metadata_service/patients/api_views.py
+++ b/chord_metadata_service/patients/api_views.py
@@ -282,4 +282,3 @@ class BeaconListIndividuals(APIView):
                 "experiment_type": experiment_types
             }
         })
-

--- a/chord_metadata_service/patients/api_views.py
+++ b/chord_metadata_service/patients/api_views.py
@@ -229,7 +229,7 @@ class BeaconListIndividuals(APIView):
         search_conf = settings.CONFIG_PUBLIC["search"]
         field_conf = settings.CONFIG_PUBLIC["fields"]
         queryable_fields = {
-            f"{f}": field_conf[f] for section in search_conf for f in section["fields"]
+            f: field_conf[f] for section in search_conf for f in section["fields"]
         }
 
         for field, value in qp.items():

--- a/chord_metadata_service/patients/api_views.py
+++ b/chord_metadata_service/patients/api_views.py
@@ -258,7 +258,7 @@ class BeaconListIndividuals(APIView):
 
     def get(self, request, *args, **kwargs):
         if not settings.CONFIG_PUBLIC:
-            return Response(settings.NO_PUBLIC_DATA_AVAILABLE, status=400)
+            return Response(settings.NO_PUBLIC_DATA_AVAILABLE, status=404)
 
         base_qs = Individual.objects.all()
         try:

--- a/chord_metadata_service/patients/tests/test_api.py
+++ b/chord_metadata_service/patients/tests/test_api.py
@@ -674,28 +674,20 @@ class BeaconSearchTest(APITestCase):
     def test_beacon_search_response_no_config(self):
         # test when config is not provided, returns NO_PUBLIC_DATA_AVAILABLE
         response = self.client.get('/api/beacon_search?sex=MALE')
-        self.assertEqual(response.status_code, status.HTTP_200_OK)
-        response_obj = response.json()
-        self.assertIsInstance(response_obj, dict)
-        self.assertEqual(response_obj, settings.NO_PUBLIC_DATA_AVAILABLE)
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
 
     @override_settings(CONFIG_PUBLIC=CONFIG_PUBLIC_TEST)
     def test_beacon_search_response_invalid_search_key(self):
         response = self.client.get('/api/beacon_search?birdwatcher=yes')
-        self.assertEqual(response.status_code, status.HTTP_200_OK)
-        response_obj = response.json()
-        self.assertEqual(response_obj["code"], 400)
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
 
     @override_settings(CONFIG_PUBLIC=CONFIG_PUBLIC_TEST)
     def test_beacon_search_response_invalid_search_value(self):
         response = self.client.get('/api/beacon_search?smoking=on_Sundays')
-        self.assertEqual(response.status_code, status.HTTP_200_OK)
-        response_obj = response.json()
-        self.assertEqual(response_obj["code"], 400)
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
 
     @override_settings(CONFIG_PUBLIC=CONFIG_PUBLIC_TEST)
     def test_beacon_search_too_many_params(self):
         response = self.client.get('/api/beacon_search?sex=MALE&smoking=Non-smoker&death_dc=Deceased')
-        self.assertEqual(response.status_code, status.HTTP_200_OK)
-        response_obj = response.json()
-        self.assertEqual(response_obj["code"], 400)
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+

--- a/chord_metadata_service/patients/tests/test_api.py
+++ b/chord_metadata_service/patients/tests/test_api.py
@@ -672,7 +672,7 @@ class BeaconSearchTest(APITestCase):
 
     @override_settings(CONFIG_PUBLIC={})
     def test_beacon_search_response_no_config(self):
-        # test when config is not provided, returns NO_PUBLIC_DATA_AVAILABLE
+        # test when config is not provided, returns BAD_REQUEST
         response = self.client.get('/api/beacon_search?sex=MALE')
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
 

--- a/chord_metadata_service/patients/tests/test_api.py
+++ b/chord_metadata_service/patients/tests/test_api.py
@@ -650,3 +650,12 @@ class PublicAgeRangeFilteringIndividualsTest(APITestCase):
         self.assertIsInstance(response_obj, dict)
         self.assertIsInstance(response_obj, dict)
         self.assertEqual(response_obj, settings.NO_PUBLIC_DATA_AVAILABLE)
+
+    # test beacon formatted response
+    @override_settings(CONFIG_PUBLIC=CONFIG_PUBLIC_TEST)
+    def test_public_filtering_beacon_response(self):
+        response = self.client.get('/api/public?sex=MALE&response_format=beacon')
+        male_count = Individual.objects.filter(sex="MALE").count()
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        response_obj = response.json()
+        self.assertEqual(len(response_obj["matches"]), male_count)

--- a/chord_metadata_service/patients/tests/test_api.py
+++ b/chord_metadata_service/patients/tests/test_api.py
@@ -690,4 +690,3 @@ class BeaconSearchTest(APITestCase):
     def test_beacon_search_too_many_params(self):
         response = self.client.get('/api/beacon_search?sex=MALE&smoking=Non-smoker&death_dc=Deceased')
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
-

--- a/chord_metadata_service/patients/tests/test_api.py
+++ b/chord_metadata_service/patients/tests/test_api.py
@@ -657,7 +657,7 @@ class BeaconSearchTest(APITestCase):
     random_range = 20
 
     def setUp(self):
-        individuals = [c.generate_valid_individual() for _ in range(self.random_range)]  
+        individuals = [c.generate_valid_individual() for _ in range(self.random_range)]
         for individual in individuals:
             Individual.objects.create(**individual)
 

--- a/chord_metadata_service/patients/tests/test_api.py
+++ b/chord_metadata_service/patients/tests/test_api.py
@@ -674,7 +674,7 @@ class BeaconSearchTest(APITestCase):
     def test_beacon_search_response_no_config(self):
         # test when config is not provided, returns BAD_REQUEST
         response = self.client.get('/api/beacon_search?sex=MALE')
-        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
 
     @override_settings(CONFIG_PUBLIC=CONFIG_PUBLIC_TEST)
     def test_beacon_search_response_invalid_search_key(self):

--- a/chord_metadata_service/patients/tests/test_api.py
+++ b/chord_metadata_service/patients/tests/test_api.py
@@ -651,10 +651,20 @@ class PublicAgeRangeFilteringIndividualsTest(APITestCase):
         self.assertIsInstance(response_obj, dict)
         self.assertEqual(response_obj, settings.NO_PUBLIC_DATA_AVAILABLE)
 
+
+class BeaconSearchTest(APITestCase):
+
+    random_range = 20
+
+    def setUp(self):
+        individuals = [c.generate_valid_individual() for _ in range(self.random_range)]  
+        for individual in individuals:
+            Individual.objects.create(**individual)
+
     # test beacon formatted response
     @override_settings(CONFIG_PUBLIC=CONFIG_PUBLIC_TEST)
     def test_public_filtering_beacon_response(self):
-        response = self.client.get('/api/public?sex=MALE&response_format=beacon')
+        response = self.client.get('/api/beacon_search?sex=MALE')
         male_count = Individual.objects.filter(sex="MALE").count()
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         response_obj = response.json()

--- a/chord_metadata_service/patients/tests/test_api.py
+++ b/chord_metadata_service/patients/tests/test_api.py
@@ -672,7 +672,7 @@ class BeaconSearchTest(APITestCase):
 
     @override_settings(CONFIG_PUBLIC={})
     def test_beacon_search_response_no_config(self):
-        # test when config is not provided, returns BAD_REQUEST
+        # test when config is not provided, returns NOT FOUND
         response = self.client.get('/api/beacon_search?sex=MALE')
         self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
 

--- a/chord_metadata_service/restapi/urls.py
+++ b/chord_metadata_service/restapi/urls.py
@@ -96,7 +96,8 @@ urlpatterns = [
     path('biosample_sampled_tissue_autocomplete', BiosampleSampledTissueAutocomplete.as_view(),
          name='biosample-sampled-tissue-autocomplete',),
 
-    # public endpoints (no confidential information leak)
+    # endpoints for bento public
+    # used by beacon or public backend, not meant for open access use
     path('public', individual_views.PublicListIndividuals.as_view(),
          name='public',),
     path('public_search_fields', public_search_fields, name='public-search-fields',),

--- a/chord_metadata_service/restapi/urls.py
+++ b/chord_metadata_service/restapi/urls.py
@@ -96,11 +96,13 @@ urlpatterns = [
     path('biosample_sampled_tissue_autocomplete', BiosampleSampledTissueAutocomplete.as_view(),
          name='biosample-sampled-tissue-autocomplete',),
 
-    # endpoints for bento public
-    # used by beacon or public backend, not meant for open access use
+    # public endpoints (no confidential information leak)
     path('public', individual_views.PublicListIndividuals.as_view(),
          name='public',),
     path('public_search_fields', public_search_fields, name='public-search-fields',),
     path('public_overview', public_overview, name='public-overview',),
     path('public_dataset', public_dataset, name='public-dataset'),
+
+    # uncensored endpoint for beacon search using fields from config.json
+    path('beacon_search', individual_views.BeaconListIndividuals.as_view(), name='beacon-search'),
 ]


### PR DESCRIPTION
Create a new katsu endpoint `/api/beacon_search`, an uncensored equivalent to the bento_public search endpoint `/api/public`. Returns a full list of matching individual ids rather than censored counts, so that  beacon can compute the intersection of results with other searches (in particular for variants). Beacon instead of katsu will apply censorship in this case. 

This allows beacon to use katsu's config for search, which gets us:
1. configurable search, only specific searches are permitted, and
2. fast extra properties seach, currently not available elsewhere in katsu 

