### PR TITLE
change exp_type elisa to neutralizing antibody

### DIFF
--- a/chord_metadata_service/experiments/schemas.py
+++ b/chord_metadata_service/experiments/schemas.py
@@ -92,7 +92,7 @@ EXPERIMENT_SCHEMA = tag_ids_and_describe({
             "type": "string",
             "enum": ["DNA Methylation", "mRNA-Seq", "smRNA-Seq", "RNA-Seq", "WES",
                      "WGS", "Genotyping", "Proteomic profiling",
-                     "Enzyme-linked immunosorbent assay", "Metabolite profiling",
+                     "Neutralizing antibody titers", "Metabolite profiling",
                      "Antibody measurement", "Other"]
         },
         "experiment_ontology": ONTOLOGY_CLASS_LIST,


### PR DESCRIPTION
Current PR modifies the validator to correct experiment_type Enzyme-linked immunosorbent assay to Neutralizing antibody titers

changes include
- modify the experiments schema
