### PR TITLE
patch: fix unwanted origin schema mutation for required extra_properties

### DIFF
--- a/chord_metadata_service/restapi/schema_utils.py
+++ b/chord_metadata_service/restapi/schema_utils.py
@@ -2,6 +2,7 @@ from chord_metadata_service.logger import logger
 from bento_lib.search import queries as q
 from .description_utils import describe_schema
 from typing import List, Optional, Dict
+from copy import deepcopy
 
 __all__ = [
     "merge_schema_dictionaries",
@@ -154,13 +155,13 @@ def patch_project_schemas(base_schema: dict, extension_schemas: Dict[str, object
     if not isinstance(base_schema, dict) or "type" not in base_schema:
         return base_schema
 
-    patched_schema = {**base_schema}
+    patched_schema = deepcopy(base_schema)
     if patched_schema["type"] == "object":
         # check if current object schema needs an extra_properties patch
 
         # Get the last term of the schema $id to match with SchemaType
         # e.g. 'katsu:phenopackets:phenopacket' -> 'phenopacket'
-        schema_id = base_schema["$id"].split(":")[-1] if "$id" in base_schema else None
+        schema_id = patched_schema["$id"].split(":")[-1] if "$id" in patched_schema else None
 
         if schema_id and schema_id in extension_schemas:
             ext_schema = extension_schemas[schema_id]


### PR DESCRIPTION
**Issue:** The function schema_utils.patch_project_schemas was causing a mutation on the reference of its base_schema argument. This causes bugs after removing project schemas, as if they were not removed from the DB (they are).
**Fix:** Use deepcopy to remove the reference in the local var and prevent the side effect to occur. 

**Steps to test:**
1. Create a project, dataset, and phenopacket table
2. Create an extra properties schema with **required=true**
3. Run an ingestion (it can fail or pass, doesn't matter)
4. Delete the extra properties schema
5. Run a new ingestion (should pass, was failing)