### PR TITLE
Add endpoint for fetch extraPropertiesSchemaTypes

### DIFF
--- a/chord_metadata_service/restapi/api_views.py
+++ b/chord_metadata_service/restapi/api_views.py
@@ -27,6 +27,7 @@ from chord_metadata_service.mcode import models as mcode_models
 from chord_metadata_service.patients import models as patients_models
 from chord_metadata_service.experiments import models as experiments_models
 from chord_metadata_service.mcode.api_views import MCODEPACKET_PREFETCH, MCODEPACKET_SELECT
+from chord_metadata_service.restapi.models import SchemaType
 from drf_spectacular.utils import extend_schema, inline_serializer
 from rest_framework import serializers
 
@@ -139,6 +140,15 @@ def overview(_request):
 
     return Response(r)
 
+@api_view(["GET"])
+@permission_classes([OverrideOrSuperUserOnly])
+def extra_properties_schema_types(_request):
+    """
+    get:
+    Extra properties schema types
+    """
+    schema_types = dict(SchemaType.choices)
+    return Response(schema_types)
 
 @api_view(["GET", "POST"])
 @permission_classes([OverrideOrSuperUserOnly])

--- a/chord_metadata_service/restapi/api_views.py
+++ b/chord_metadata_service/restapi/api_views.py
@@ -140,6 +140,7 @@ def overview(_request):
 
     return Response(r)
 
+
 @api_view(["GET"])
 @permission_classes([OverrideOrSuperUserOnly])
 def extra_properties_schema_types(_request):
@@ -149,6 +150,7 @@ def extra_properties_schema_types(_request):
     """
     schema_types = dict(SchemaType.choices)
     return Response(schema_types)
+
 
 @api_view(["GET", "POST"])
 @permission_classes([OverrideOrSuperUserOnly])

--- a/chord_metadata_service/restapi/tests/test_api.py
+++ b/chord_metadata_service/restapi/tests/test_api.py
@@ -36,6 +36,19 @@ class ServiceInfoTest(APITestCase):
         # TODO: Test compliance with spec
 
 
+class ExtraPropertiesSchemaTypesTest(APITestCase):
+    def test_extra_properties_schema_types(self):
+        response = self.client.get('/api/extra_properties_schema_types')
+        response_obj = response.json()
+        expected_response = {
+            "PHENOPACKET": "Phenopacket",
+            "BIOSAMPLE": "Biosample",
+            "INDIVIDUAL": "Individual"
+        }
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response_obj, expected_response)
+
+
 class OverviewTest(APITestCase):
 
     def setUp(self) -> None:

--- a/chord_metadata_service/restapi/urls.py
+++ b/chord_metadata_service/restapi/urls.py
@@ -18,7 +18,8 @@ from .api_views import (
      public_search_fields,
      public_overview,
      public_dataset,
-     search_overview
+     search_overview,
+     extra_properties_schema_types,
 )
 from chord_metadata_service.restapi.routers import BatchListRouter
 
@@ -88,6 +89,9 @@ urlpatterns = [
          name="experiment-schema"),
     path('mcode_schema', mcode_views.get_mcode_schema,
          name="mcode-schema"),
+
+    # extra properties schema types
+    path('extra_properties_schema_types', extra_properties_schema_types, name="extra-properties-schema-types"),
 
     # overviews (statistics)
     path('overview', overview, name="overview"),


### PR DESCRIPTION
In this PR, is introduced the endpoint, /extra_properties_schema_types. It is aimed at fetching and returning the extra properties schema types.

- A new view, extra_properties_schema_types, was added. This view fetches the schema types and returns them as a dictionary.
- The new view is registered in the URL configuration with the path extra_properties_schema_types.