### PR TITLE
refact: make cleanup functions async

### DIFF
--- a/chord_metadata_service/chord/serializers.py
+++ b/chord_metadata_service/chord/serializers.py
@@ -9,7 +9,11 @@ from .models import Project, Dataset, ProjectJsonSchema
 from .schemas import LINKED_FIELD_SETS_SCHEMA
 
 
-__all__ = ["ProjectSerializer", "DatasetSerializer"]
+__all__ = [
+    "ProjectSerializer",
+    "ProjectJsonSchemaSerializer",
+    "DatasetSerializer",
+]
 
 
 BENTO_DATA_USE_SCHEMA_VALIDATOR = Draft7Validator(BENTO_DATA_USE_SCHEMA)

--- a/chord_metadata_service/chord/tests/test_api_export.py
+++ b/chord_metadata_service/chord/tests/test_api_export.py
@@ -9,7 +9,7 @@ from chord_metadata_service.chord.export.utils import EXPORT_DIR
 from rest_framework import status
 from rest_framework.test import APITestCase
 
-from ..ingest.views import METADATA_WORKFLOWS
+from ..workflows.metadata import METADATA_WORKFLOWS
 from chord_metadata_service.chord.models import Project, Dataset
 from chord_metadata_service.chord.ingest import WORKFLOW_INGEST_FUNCTION_MAP
 from chord_metadata_service.chord.workflows.metadata import WORKFLOW_PHENOPACKETS_JSON

--- a/chord_metadata_service/chord/views_data_types.py
+++ b/chord_metadata_service/chord/views_data_types.py
@@ -156,15 +156,19 @@ async def dataset_data_type(request: HttpRequest, dataset_id: str, data_type: st
         return Response(status=status.HTTP_204_NO_CONTENT)
 
     project = await Project.objects.aget(datasets=dataset_id)
-    response_object = await make_data_type_response_object(data_type, dt.DATA_TYPES[data_type],
-                                                           project=str(project.identifier), dataset=dataset_id)
+    response_object = await make_data_type_response_object(
+        data_type,
+        dt.DATA_TYPES[data_type],
+        project=str(project.identifier),
+        dataset=dataset_id,
+    )
 
     return Response(response_object)
 
 
 @api_view(["GET"])
 @permission_classes([OverrideOrSuperUserOnly | ReadOnly])
-async def dataset_datatype_summary(request: HttpRequest, dataset_id: str):
+async def dataset_datatype_summary(_request: HttpRequest, dataset_id: str):
     dataset = await Dataset.objects.aget(identifier=dataset_id)
     project = await Project.objects.aget(datasets=dataset)
 

--- a/chord_metadata_service/cleanup/remove.py
+++ b/chord_metadata_service/cleanup/remove.py
@@ -2,7 +2,7 @@ from django.db.models import Model
 from typing import Set, Type, Union
 
 from ..logger import logger
-from ..utils import dict_first_val
+from ..utils import build_id_set
 
 __all__ = [
     "remove_items",
@@ -10,24 +10,24 @@ __all__ = [
 ]
 
 
-def remove_items(model: Type[Model], to_remove: Set[Union[int, str, None]], name_plural: str) -> int:
+async def remove_items(model: Type[Model], to_remove: Set[Union[int, str, None]], name_plural: str) -> int:
     n_to_remove = len(to_remove)
 
     if n_to_remove:
         logger.info(f"Automatically cleaning up {n_to_remove} {name_plural}: {str(to_remove)}")
-        model.objects.filter(id__in=to_remove).delete()
+        await model.objects.filter(id__in=to_remove).adelete()
     else:
         logger.info(f"No {name_plural} set for auto-removal")
 
     return n_to_remove
 
 
-def remove_not_referenced(model: Type[Model], references: Set[Union[int, str, None]], name_plural: str) -> int:
+async def remove_not_referenced(model: Type[Model], references: Set[Union[int, str, None]], name_plural: str) -> int:
     objs_referenced = references.copy()
 
     # Remove null from set
     objs_referenced.discard(None)
 
     # Remove objects NOT in reference set
-    objs_to_remove = set(map(dict_first_val, model.objects.exclude(id__in=objs_referenced).values("id")))
-    return remove_items(model, objs_to_remove, name_plural)
+    objs_to_remove = await build_id_set(model.objects.exclude(id__in=objs_referenced), "id")
+    return await remove_items(model, objs_to_remove, name_plural)

--- a/chord_metadata_service/cleanup/run_all.py
+++ b/chord_metadata_service/cleanup/run_all.py
@@ -8,27 +8,28 @@ __all__ = [
 ]
 
 
-def run_all_cleanup() -> int:
+async def run_all_cleanup() -> int:
     # Specific order: biosamples, then experiment artifacts (results/instruments), then patients,
     # then resources (where order is less important)
+    # TODO: figure out where order doesn't matter and use parallel asyncio.gather
 
     n_removed: int = 0
 
     # Phenopacket artifacts - metadata objects + biosamples + phenotypic features + procedures (order matters!)
-    n_removed += pc.clean_meta_data()
-    n_removed += pc.clean_biosamples()
-    n_removed += pc.clean_phenotypic_features()
-    n_removed += pc.clean_procedures()
+    n_removed += await pc.clean_meta_data()
+    n_removed += await pc.clean_biosamples()
+    n_removed += await pc.clean_phenotypic_features()
+    n_removed += await pc.clean_procedures()
 
     # Experiment artifacts
-    n_removed += ec.clean_experiment_results()
-    n_removed += ec.clean_instruments()
+    n_removed += await ec.clean_experiment_results()
+    n_removed += await ec.clean_instruments()
 
     # Patients
-    n_removed += clean_individuals()
+    n_removed += await clean_individuals()
 
     # Resources
-    n_removed += clean_resources()
+    n_removed += await clean_resources()
 
     # Return final removed object count
     return n_removed

--- a/chord_metadata_service/experiments/cleanup.py
+++ b/chord_metadata_service/experiments/cleanup.py
@@ -1,7 +1,7 @@
 # TODO
 
 from chord_metadata_service.cleanup.remove import remove_not_referenced
-from chord_metadata_service.utils import dict_first_val
+from chord_metadata_service.utils import build_id_set_from_model
 from .models import Experiment, ExperimentResult, Instrument
 
 __all__ = [
@@ -11,21 +11,21 @@ __all__ = [
 
 
 # TODO: Remove this when we have one-to-many ?
-def clean_experiment_results() -> int:
+async def clean_experiment_results() -> int:
     results_referenced = set()
 
     # Collect references to results from experiments
-    results_referenced.update(map(dict_first_val, Experiment.objects.values("experiment_results__id")))
+    results_referenced |= await build_id_set_from_model(Experiment, "experiment_results__id")
 
     # Remove experiment results NOT in set
-    return remove_not_referenced(ExperimentResult, results_referenced, "experiment results")
+    return await remove_not_referenced(ExperimentResult, results_referenced, "experiment results")
 
 
-def clean_instruments() -> int:
+async def clean_instruments() -> int:
     instruments_referenced = set()
 
     # Collect references to instruments from experiments
-    instruments_referenced.update(map(dict_first_val, Experiment.objects.values("instrument_id")))
+    instruments_referenced |= await build_id_set_from_model(Experiment, "instrument_id")
 
     # Remove instruments NOT in set
-    return remove_not_referenced(Instrument, instruments_referenced, "instruments")
+    return await remove_not_referenced(Instrument, instruments_referenced, "instruments")

--- a/chord_metadata_service/phenopackets/cleanup.py
+++ b/chord_metadata_service/phenopackets/cleanup.py
@@ -2,7 +2,7 @@ import chord_metadata_service.experiments.models as em
 import chord_metadata_service.phenopackets.models as pm
 
 from chord_metadata_service.cleanup.remove import remove_items, remove_not_referenced
-from chord_metadata_service.utils import dict_first_val
+from chord_metadata_service.utils import build_id_set, build_id_set_from_model
 
 __all__ = [
     "clean_meta_data",
@@ -12,20 +12,20 @@ __all__ = [
 ]
 
 
-def clean_meta_data() -> int:
+async def clean_meta_data() -> int:
     """
     Deletes orphan MetaData objects where the parent phenopacket has been deleted.
     TODO: This should be handled by a OneToOne relationship rather than this hack.
     """
 
     # Collect references to meta data
-    meta_data_referenced = set(map(dict_first_val, pm.Phenopacket.objects.values("meta_data_id")))
+    meta_data_referenced = await build_id_set_from_model(pm.Phenopacket, "meta_data_id")
 
     # Remove metadata not referenced
-    return remove_not_referenced(pm.MetaData, meta_data_referenced, "metadata objects")
+    return await remove_not_referenced(pm.MetaData, meta_data_referenced, "metadata objects")
 
 
-def clean_biosamples() -> int:
+async def clean_biosamples() -> int:
     """
     Deletes all biosamples which aren't referenced anywhere in the application.
     Phenopackets and Experiments model tables should be deleted in the database
@@ -35,15 +35,15 @@ def clean_biosamples() -> int:
     biosamples_referenced = set()
 
     # Collect references to biosamples in other data types
-    biosamples_referenced.update(map(dict_first_val, pm.Phenopacket.objects.values("biosamples__id")))
-    biosamples_referenced.update(map(dict_first_val, em.Experiment.objects.values("biosample_id")))
+    biosamples_referenced |= await build_id_set_from_model(pm.Phenopacket, "biosamples__id")
+    biosamples_referenced |= await build_id_set_from_model(em.Experiment, "biosample_id")
     # Explicitly don't check for phenotypic features here - they are attached to biosamples/phenopackets,
     #   and we want to delete them if the biosamples are otherwised not referenced elsewhere.
 
-    return remove_not_referenced(pm.Biosample, biosamples_referenced, "biosamples")
+    return await remove_not_referenced(pm.Biosample, biosamples_referenced, "biosamples")
 
 
-def clean_phenotypic_features() -> int:
+async def clean_phenotypic_features() -> int:
     """
     Deletes all phenotypic features without a biosample or phenopacket. This could
     happen especially in versions prior to 2.17.0, where on_delete was SET_NULL for both.
@@ -53,15 +53,17 @@ def clean_phenotypic_features() -> int:
 
     # We can skip some steps and collect only those not used directly here.
 
-    pf_to_remove_qs = pm.PhenotypicFeature.objects.filter(
-        biosample__isnull=True,
-        phenopacket__isnull=True,
+    pf_to_remove = await build_id_set(
+        qs=pm.PhenotypicFeature.objects.filter(
+            biosample__isnull=True,
+            phenopacket__isnull=True,
+        ),
+        field="id",
     )
-    pf_to_remove = set(map(dict_first_val, pf_to_remove_qs.values("id")))
-    return remove_items(pm.PhenotypicFeature, pf_to_remove, "phenotypic features")
+    return await remove_items(pm.PhenotypicFeature, pf_to_remove, "phenotypic features")
 
 
-def clean_procedures() -> int:
+async def clean_procedures() -> int:
     """
     Deletes all procedures which aren't pointed to by at least one biosample, since
     there is a many biosample -> one procedure style relationship currently (2023-01-19).
@@ -70,6 +72,6 @@ def clean_procedures() -> int:
     procedures_referenced = set()
 
     # Collect references to procedures in biosamples
-    procedures_referenced.update(map(dict_first_val, pm.Biosample.objects.values("procedure_id")))
+    procedures_referenced |= await build_id_set_from_model(pm.Biosample, "procedure_id")
 
-    return remove_not_referenced(pm.Procedure, procedures_referenced, "procedures")
+    return await remove_not_referenced(pm.Procedure, procedures_referenced, "procedures")

--- a/chord_metadata_service/resources/cleanup.py
+++ b/chord_metadata_service/resources/cleanup.py
@@ -4,21 +4,21 @@ import chord_metadata_service.phenopackets.models as pm
 from .models import Resource
 
 from chord_metadata_service.cleanup.remove import remove_not_referenced
-from chord_metadata_service.utils import dict_first_val
+from chord_metadata_service.utils import build_id_set_from_model
 
 __all__ = [
     "clean_resources",
 ]
 
 
-def clean_resources() -> int:
+async def clean_resources() -> int:
     """
     Removes any resources not referenced by any datasets/phenopackets.
     """
 
     resources_referenced = set()
 
-    resources_referenced.update(map(dict_first_val, cm.Dataset.objects.values("additional_resources__id")))
-    resources_referenced.update(map(dict_first_val, pm.MetaData.objects.values("resources__id")))
+    resources_referenced |= await build_id_set_from_model(cm.Dataset, "additional_resources__id")
+    resources_referenced |= await build_id_set_from_model(pm.MetaData, "resources__id")
 
-    return remove_not_referenced(Resource, resources_referenced, "resources")
+    return await remove_not_referenced(Resource, resources_referenced, "resources")

--- a/chord_metadata_service/utils.py
+++ b/chord_metadata_service/utils.py
@@ -1,9 +1,18 @@
-from typing import Any
+from django.db.models import Model, QuerySet
+from typing import Any, Set, Type
 
 __all__ = [
-    "dict_first_val",
+    "build_id_set",
+    "build_id_set_from_model",
 ]
 
 
-def dict_first_val(x: dict) -> Any:
-    return tuple(x.values())[0]
+async def build_id_set(qs: QuerySet, field: str) -> Set[Any]:
+    s = set()
+    async for v in qs.values_list(field, flat=True):
+        s.add(v)
+    return s
+
+
+async def build_id_set_from_model(m: Type[Model], field: str) -> Set[Any]:
+    return await build_id_set(m.objects.all(), field)


### PR DESCRIPTION
This will enable cleanup for the new dataset data type endpoints.

One test is failing but this is from unrelated work in the base branch here, not from changes.