### PR TITLE
remove censorship from search code for beacon

### DIFF
--- a/chord_metadata_service/patients/api_views.py
+++ b/chord_metadata_service/patients/api_views.py
@@ -248,9 +248,6 @@ class BeaconListIndividuals(APIView):
     def filter_queryset(self, queryset):
         # Check query parameters validity
         qp = self.request.query_params
-        if len(qp) > settings.CONFIG_PUBLIC["rules"]["max_query_parameters"]:
-            raise ValidationError(f"Wrong number of fields: {len(qp)}")
-
         search_conf = settings.CONFIG_PUBLIC["search"]
         field_conf = settings.CONFIG_PUBLIC["fields"]
         queryable_fields = {

--- a/chord_metadata_service/patients/tests/test_api.py
+++ b/chord_metadata_service/patients/tests/test_api.py
@@ -731,6 +731,6 @@ class BeaconSearchTest(APITestCase):
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
 
     @override_settings(CONFIG_PUBLIC=CONFIG_PUBLIC_TEST)
-    def test_beacon_search_too_many_params(self):
+    def test_beacon_search_more_params_than_censorship_limit(self):
         response = self.client.get('/api/beacon_search?sex=MALE&smoking=Non-smoker&death_dc=Deceased')
-        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)


### PR DESCRIPTION
Don't apply "max query params" censorship to search code for beacon; beacon handles its own censorship.