### PR TITLE
chore: rm enum values for experiment_result.genome_assembly_id

### DIFF
--- a/chord_metadata_service/experiments/schemas.py
+++ b/chord_metadata_service/experiments/schemas.py
@@ -25,7 +25,6 @@ EXPERIMENT_RESULT_SCHEMA = tag_ids_and_describe({
         },
         "genome_assembly_id": {
             "type": "string",
-            "enum": ["GRCh37", "GRCh38", "GRCm38", "GRCm39"]
         },
         "file_format": {
             "type": "string",

--- a/docs/modules/experiments_api.rst
+++ b/docs/modules/experiments_api.rst
@@ -56,7 +56,6 @@ The following **filters** can be applied:
 - ``filename`` (single, case-insensitive, partial match): :code:`/api/experimentresults?filename=1001_rnaseq.bw`
 
 - ``genome_assembly_id`` (single, case-insensitive, exact match): :code:`/api/experimentresults?genome_assembly_id=GRCh37`
-  options: GRCh37, GRCh38, GRCm38, GRCm39
 
 - ``file_format`` (single, case-insensitive, exact match): :code:`/api/experimentresults?file_format=VCF`
 


### PR DESCRIPTION
In order to support the reference service, this should be free-form (de facto a 'foreign key' to the reference service.) In the future, this should be validated on ingestion against the reference service.