### PR TITLE
chore!: impose more lenient ID regex across routers/schemas

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,7 +20,7 @@ jobs:
         python-version: ["3.10", "3.11"]
     services:
       postgres:
-        image: postgres:15
+        image: postgres:16
         env:
           POSTGRES_DB: postgres
           POSTGRES_PASSWORD: postgres
@@ -46,4 +46,6 @@ jobs:
         export POSTGRES_USER="postgres" && export POSTGRES_PASSWORD="postgres" && export POSTGRES_PORT=5432
         poetry run coverage run ./manage.py test
     - name: Upload Coverage to Codecov
-      uses: codecov/codecov-action@v3
+      uses: codecov/codecov-action@v4
+      env:
+        CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}

--- a/chord_metadata_service/chord/tests/test_api_search.py
+++ b/chord_metadata_service/chord/tests/test_api_search.py
@@ -373,10 +373,13 @@ class SearchTest(APITestCase):
             self.assertEqual(r.status_code, status.HTTP_200_OK)
             c = r.json()
             self.assertEqual(len(c["results"]), 1)  # 1 phenopacket that contains 2 matching biosamples
-            self.assertIn("biosample_id:1", [b["id"]
-                                             for phenopacket in c["results"]
-                                             for b in phenopacket["biosamples"]
-                                             ])
+            self.assertIn(
+                "katsu.biosample_id:1",
+                [
+                    b["id"]
+                    for phenopacket in c["results"]
+                    for b in phenopacket["biosamples"]
+                ])
 
     def test_private_dataset_search_values_list(self):
         # Valid query to search for biosample id in list

--- a/chord_metadata_service/experiments/api_views.py
+++ b/chord_metadata_service/experiments/api_views.py
@@ -10,6 +10,7 @@ from .serializers import ExperimentSerializer, ExperimentResultSerializer
 from .models import Experiment, ExperimentResult
 from .schemas import EXPERIMENT_SCHEMA
 from .filters import ExperimentFilter, ExperimentResultFilter
+from chord_metadata_service.restapi.constants import MODEL_ID_PATTERN
 from chord_metadata_service.restapi.pagination import LargeResultsSetPagination, BatchResultsSetPagination
 
 
@@ -56,6 +57,7 @@ class ExperimentViewSet(viewsets.ModelViewSet):
     renderer_classes = tuple(api_settings.DEFAULT_RENDERER_CLASSES)
     filter_backends = [DjangoFilterBackend]
     filterset_class = ExperimentFilter
+    lookup_value_regex = MODEL_ID_PATTERN
 
     def dispatch(self, *args, **kwargs):
         return super(ExperimentViewSet, self).dispatch(*args, **kwargs)

--- a/chord_metadata_service/experiments/schemas.py
+++ b/chord_metadata_service/experiments/schemas.py
@@ -1,5 +1,6 @@
 from pathlib import Path
 from .descriptions import EXPERIMENT, EXPERIMENT_RESULT, INSTRUMENT
+from chord_metadata_service.restapi.constants import MODEL_ID_PATTERN
 from chord_metadata_service.restapi.schemas import ONTOLOGY_CLASS_LIST, KEY_VALUE_OBJECT
 from chord_metadata_service.restapi.schema_utils import tag_ids_and_describe, get_schema_app_id, sub_schema_uri
 
@@ -134,7 +135,8 @@ EXPERIMENT_SCHEMA = tag_ids_and_describe({
     "type": "object",
     "properties": {
         "id": {
-            "type": "string"
+            "type": "string",
+            "pattern": MODEL_ID_PATTERN,
         },
         "study_type": {
             "type": "string",

--- a/chord_metadata_service/experiments/tests/example_experiments.json
+++ b/chord_metadata_service/experiments/tests/example_experiments.json
@@ -1,7 +1,7 @@
 {
   "experiments": [
     {
-      "id": "experiment:1",
+      "id": "katsu.experiment:1",
       "biosample": "sample1",
       "study_type": "Epigenomics",
       "experiment_type": "WES",
@@ -69,7 +69,7 @@
       }
     },
     {
-      "id": "experiment:2",
+      "id": "katsu.experiment:2",
       "biosample": "sample8",
       "study_type": "Epigenomics",
       "experiment_type": "WES",

--- a/chord_metadata_service/experiments/tests/test_api.py
+++ b/chord_metadata_service/experiments/tests/test_api.py
@@ -44,6 +44,12 @@ class GetExperimentsAppApisTest(APITestCase):
         self.assertEqual(response_data["count"], 2)
         self.assertEqual(len(response_data["results"]), 2)
 
+    def test_get_experiment_one(self):
+        response = self.client.get('/api/experiments/katsu.experiment:1')
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        response_data = response.json()
+        self.assertEqual(response_data['id'], 'katsu.experiment:1')
+
     def test_get_experiment_schema(self):
         response = self.client.get('/api/experiment_schema')
         self.assertEqual(response.status_code, status.HTTP_200_OK)
@@ -148,11 +154,11 @@ class GetExperimentsAppApisTest(APITestCase):
         self.assertEqual(len(response.json()), 2)
 
     def test_post_experiment_batch_with_ids(self):
-        response = self.client.post('/api/batch/experiments', {'id': ['experiment:1']}, format='json')
+        response = self.client.post('/api/batch/experiments', {'id': ['katsu.experiment:1']}, format='json')
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         response_data = response.json()
         self.assertEqual(len(response_data), 1)
-        self.assertEqual(response_data[0]['id'], 'experiment:1')
+        self.assertEqual(response_data[0]['id'], 'katsu.experiment:1')
 
 
 class TestExperimentCSVRenderer(TestCase):

--- a/chord_metadata_service/patients/api_views.py
+++ b/chord_metadata_service/patients/api_views.py
@@ -31,6 +31,7 @@ from chord_metadata_service.restapi.api_renderers import (
     ARGORenderer,
     IndividualBentoSearchRenderer,
 )
+from chord_metadata_service.restapi.constants import MODEL_ID_PATTERN
 from chord_metadata_service.restapi.pagination import LargeResultsSetPagination, BatchResultsSetPagination
 from chord_metadata_service.restapi.utils import (
     get_field_options,
@@ -66,6 +67,7 @@ class IndividualViewSet(viewsets.ModelViewSet):
         *(f"biosamples__{p}" for p in BIOSAMPLE_PREFETCH),
         *(f"phenopackets__{p}" for p in PHENOPACKET_PREFETCH if p != "subject"),
     ).order_by("id")
+    lookup_value_regex = MODEL_ID_PATTERN
 
     def list(self, request, *args, **kwargs):
         if request.query_params.get("format") == OUTPUT_FORMAT_BENTO_SEARCH_RESULT:

--- a/chord_metadata_service/patients/schemas.py
+++ b/chord_metadata_service/patients/schemas.py
@@ -1,5 +1,16 @@
-from chord_metadata_service.restapi.schema_utils import DATE_TIME, DRAFT_07, SchemaTypes, array_of, base_type, \
-    enum_of, tag_ids_and_describe, get_schema_app_id, sub_schema_uri
+from chord_metadata_service.restapi.constants import MODEL_ID_PATTERN
+from chord_metadata_service.restapi.schema_utils import (
+    DATE_TIME,
+    DRAFT_07,
+    SchemaTypes,
+    array_of,
+    base_type,
+    string_with_pattern,
+    enum_of,
+    tag_ids_and_describe,
+    get_schema_app_id,
+    sub_schema_uri,
+)
 from chord_metadata_service.restapi.schemas import ONTOLOGY_CLASS, EXTRA_PROPERTIES_SCHEMA, TIME_ELEMENT_SCHEMA
 from pathlib import Path
 from .descriptions import INDIVIDUAL, VITAL_STATUS
@@ -28,7 +39,10 @@ INDIVIDUAL_SCHEMA = tag_ids_and_describe({
     "type": "object",
     "properties": {
         # Phenopacket V2 Individual fields
-        "id": base_type(SchemaTypes.STRING, description="Unique researcher-specified identifier for the individual."),
+        "id": string_with_pattern(
+            MODEL_ID_PATTERN,
+            description="Unique researcher-specified identifier for the individual.",
+        ),
         "alternate_ids": array_of(base_type(SchemaTypes.STRING)),
         "date_of_birth": DATE_TIME,
         "time_at_last_encounter": TIME_ELEMENT_SCHEMA,

--- a/chord_metadata_service/phenopackets/api_views.py
+++ b/chord_metadata_service/phenopackets/api_views.py
@@ -8,6 +8,7 @@ from rest_framework.response import Response
 from chord_metadata_service.restapi.api_renderers import (PhenopacketsRenderer, FHIRRenderer,
                                                           BiosamplesCSVRenderer, ARGORenderer,
                                                           IndividualBentoSearchRenderer)
+from chord_metadata_service.restapi.constants import MODEL_ID_PATTERN
 from chord_metadata_service.restapi.pagination import LargeResultsSetPagination, BatchResultsSetPagination
 from chord_metadata_service.restapi.negociation import FormatInPostContentNegotiation
 from chord_metadata_service.phenopackets.schemas import PHENOPACKET_SCHEMA
@@ -93,6 +94,7 @@ class BiosampleViewSet(ExtendedPhenopacketsModelViewSet):
     filter_backends = [DjangoFilterBackend]
     filterset_class = f.BiosampleFilter
     queryset = m.Biosample.objects.all().prefetch_related(*BIOSAMPLE_PREFETCH).order_by("id")
+    lookup_value_regex = MODEL_ID_PATTERN
 
 
 class BiosampleBatchViewSet(ExtendedPhenopacketsModelViewSet):
@@ -162,6 +164,7 @@ class PhenopacketViewSet(ExtendedPhenopacketsModelViewSet):
     filter_backends = [DjangoFilterBackend]
     filterset_class = f.PhenopacketFilter
     queryset = m.Phenopacket.objects.all().prefetch_related(*PHENOPACKET_PREFETCH).order_by("id")
+    lookup_value_regex = MODEL_ID_PATTERN
 
 
 class GenomicInterpretationViewSet(PhenopacketsModelViewSet):

--- a/chord_metadata_service/phenopackets/schemas.py
+++ b/chord_metadata_service/phenopackets/schemas.py
@@ -5,6 +5,7 @@ from referencing import Registry, Resource
 from referencing.jsonschema import DRAFT7
 from chord_metadata_service.patients.schemas import INDIVIDUAL_SCHEMA
 from chord_metadata_service.resources.schemas import RESOURCE_SCHEMA
+from chord_metadata_service.restapi.constants import MODEL_ID_PATTERN
 from chord_metadata_service.restapi.schemas import (
     AGE,
     AGE_RANGE,
@@ -19,6 +20,7 @@ from chord_metadata_service.restapi.schema_utils import (
     SchemaTypes,
     array_of,
     base_type,
+    string_with_pattern,
     enum_of,
     named_one_of,
     sub_schema_uri,
@@ -72,7 +74,7 @@ PHENOPACKET_EXTERNAL_REFERENCE_SCHEMA = describe_schema({
     "title": "External reference schema",
     "type": "object",
     "properties": {
-        "id": base_type(SchemaTypes.STRING),
+        "id": string_with_pattern(MODEL_ID_PATTERN),
         "reference": base_type(SchemaTypes.STRING),
         "description": base_type(SchemaTypes.STRING)
     }
@@ -277,9 +279,9 @@ PHENOPACKET_BIOSAMPLE_SCHEMA = describe_schema({
     "$id": sub_schema_uri(base_uri, "biosample"),
     "type": "object",
     "properties": {
-        "id": base_type(SchemaTypes.STRING),
-        "individual_id": base_type(SchemaTypes.STRING),
-        "derived_from_id": base_type(SchemaTypes.STRING),
+        "id": string_with_pattern(MODEL_ID_PATTERN),
+        "individual_id": string_with_pattern(MODEL_ID_PATTERN),
+        "derived_from_id": string_with_pattern(MODEL_ID_PATTERN),
         "description": base_type(SchemaTypes.STRING),
         "sampled_tissue": ONTOLOGY_CLASS,
         "sample_type": ONTOLOGY_CLASS,
@@ -647,7 +649,7 @@ PHENOPACKET_SCHEMA = describe_schema({
     "description": "Schema for metadata service datasets",
     "type": "object",
     "properties": {
-        "id": base_type(SchemaTypes.STRING),
+        "id": string_with_pattern(MODEL_ID_PATTERN),
         "subject": INDIVIDUAL_SCHEMA,
         "phenotypic_features": array_of(PHENOPACKET_PHENOTYPIC_FEATURE_SCHEMA),
         "measurements": array_of(PHENOPACKET_MEASUREMENT_SCHEMA),

--- a/chord_metadata_service/phenopackets/tests/constants.py
+++ b/chord_metadata_service/phenopackets/tests/constants.py
@@ -397,7 +397,7 @@ def valid_phenopacket(subject, meta_data):
 
 def valid_biosample_1(individual, procedure=VALID_PROCEDURE_1):
     return dict(
-        id='biosample_id:1',
+        id='katsu.biosample_id:1',
         individual_id=individual,
         description='This is a test biosample.',
         sampled_tissue={

--- a/chord_metadata_service/phenopackets/tests/test_api.py
+++ b/chord_metadata_service/phenopackets/tests/test_api.py
@@ -66,7 +66,7 @@ class CreateBiosampleTest(APITestCase):
         response = get_post_response('biosamples-list', self.valid_payload)
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
         self.assertEqual(m.Biosample.objects.count(), 1)
-        self.assertEqual(m.Biosample.objects.get().id, 'biosample_id:1')
+        self.assertEqual(m.Biosample.objects.get().id, 'katsu.biosample_id:1')
 
     def test_create_invalid_biosample(self):
         """ POST a new biosample with invalid data. """

--- a/chord_metadata_service/phenopackets/tests/test_models.py
+++ b/chord_metadata_service/phenopackets/tests/test_models.py
@@ -45,7 +45,7 @@ class BiosampleTest(ProjectTestCase):
             tumor_progression__label='Primary Malignant Neoplasm',
             sampled_tissue__label__icontains='urinary bladder'
         )
-        self.assertEqual(biosample_one.id, 'biosample_id:1')
+        self.assertEqual(biosample_one.id, 'katsu.biosample_id:1')
         self.assertEqual(biosample_one.schema_type, SchemaType.BIOSAMPLE)
         self.assertEqual(biosample_one.get_project_id(), self.project.identifier)
 

--- a/chord_metadata_service/restapi/constants.py
+++ b/chord_metadata_service/restapi/constants.py
@@ -1,0 +1,1 @@
+MODEL_ID_PATTERN = r"[a-zA-Z0-9._\-:]+"

--- a/chord_metadata_service/restapi/schema_utils.py
+++ b/chord_metadata_service/restapi/schema_utils.py
@@ -28,6 +28,7 @@ __all__ = [
     "validation_schema_list",
     "get_schema_app_id",
     "base_type",
+    "string_with_pattern",
     "array_of",
     "enum_of",
     "named_one_of",

--- a/chord_metadata_service/restapi/tests/test_fhir.py
+++ b/chord_metadata_service/restapi/tests/test_fhir.py
@@ -124,7 +124,7 @@ class FHIRPhenotypicFeatureTest(APITestCase):
                          'description')
         self.assertIsNotNone(get_resp_obj['observations'][0]['specimen'])
         self.assertIsInstance(get_resp_obj['observations'][0]['specimen'], dict)
-        self.assertEqual(get_resp_obj['observations'][0]['specimen']['reference'], 'biosample_id:1')
+        self.assertEqual(get_resp_obj['observations'][0]['specimen']['reference'], 'katsu.biosample_id:1')
 
 
 class FHIRBiosampleTest(APITestCase):


### PR DESCRIPTION
This is for models which have view-sets and user-settable IDs in ingestion.