### PR TITLE
fix: always include dats_file (even when it's false-like: `{}`)

### DIFF
--- a/chord_metadata_service/chord/serializers.py
+++ b/chord_metadata_service/chord/serializers.py
@@ -32,6 +32,7 @@ class DatasetSerializer(GenericSerializer):
         "description",
         "contact_info",
         "linked_field_sets",
+        "dats_file",
         "project",
     )
 


### PR DESCRIPTION
This will fix editing empty DATS datasets clearing the DATS field.