### PR TITLE
fix: biosamples search total count

### DIFF
--- a/chord_metadata_service/discovery/stats.py
+++ b/chord_metadata_service/discovery/stats.py
@@ -60,18 +60,15 @@ async def bento_public_format_count_and_stats_list(
 
     async for q in annotated_queryset:
         label = q["label"]
-        value = thresholded_count(int(q["value"]), discovery, low_counts_censored)
+        raw_value = int(q["value"])
+        thresholded_value = thresholded_count(int(q["value"]), discovery, low_counts_censored)
+
+        # increment with raw count for accurate total
+        total += raw_value
 
         # Be careful not to leak values if they're in the database but below threshold
-        if value == 0:
-            continue
-
-        # Skip 'missing' values
-        if label is None:
-            continue
-
-        total += value
-        stats_list.append({"label": label, "value": value})
+        if label is not None and thresholded_value > 0:
+            stats_list.append({"label": label, "value": thresholded_value})
 
     return thresholded_count(total, discovery, low_counts_censored), stats_list
 

--- a/chord_metadata_service/discovery/stats.py
+++ b/chord_metadata_service/discovery/stats.py
@@ -58,10 +58,11 @@ async def bento_public_format_count_and_stats_list(
     stats_list: list[BinWithValue] = []
     total: int = 0
 
+    # TODO: improve censorship tests for search/beacon counts/stats
     async for q in annotated_queryset:
         label = q["label"]
         raw_value = int(q["value"])
-        thresholded_value = thresholded_count(int(q["value"]), discovery, low_counts_censored)
+        thresholded_value = thresholded_count(raw_value, discovery, low_counts_censored)
 
         # increment with raw count for accurate total
         total += raw_value

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "chord_metadata_service"  # can be renamed to katsu if inner module directory is renamed too
-version = "8.0.0"
+version = "8.0.1"
 description = "An implementation of a clin/pheno metadata store for the Bento platform."
 authors = [
     "Ksenia Zaytseva",


### PR DESCRIPTION
Fixes the discrepancy in biosample counts between public-search and beacon.
- compute total count with all categories, even those with missing values or below threshold
- return `stats_list` containing only the categories that respect the threshold.