### PR TITLE
fix(chord): typo in dict comprehension leading to bad request

### DIFF
--- a/chord_metadata_service/chord/tests/test_api_bento_datasets.py
+++ b/chord_metadata_service/chord/tests/test_api_bento_datasets.py
@@ -54,8 +54,84 @@ class BentoDatasetsTest(AuthzAPITestCase, PhenoTestCase):
         self.dataset.refresh_from_db()  # confirm this still exists in database, otherwise it'll raise DoesNotExist
 
     def test_dataset_summary(self):
+        self.maxDiff = None  # allow full assertDictEqual diff if something goes awry
         r = self.dt_authz_full_get(reverse("chord-dataset-summary", kwargs={"dataset_id": self.dataset.identifier}))
         self.assertEqual(r.status_code, status.HTTP_200_OK)
+        data = r.json()
+        self.assertEqual(type(data), dict)
+        self.assertDictEqual(data, {
+            "phenopacket": {
+                "count": 1,
+                "data_type_specific": {
+                    "biosamples": {
+                        "count": 2,
+                        "histological_diagnosis": {"Infiltrating Urothelial Carcinoma": 2},
+                        "is_control_sample": {"False": 1, "True": 1},
+                        "sampled_tissue": {"urinary bladder": 1, "wall of urinary bladder": 1},
+                        "taxonomy": {"Homo sapiens": 2}
+                    },
+                    "diseases": {
+                        "count": 1,
+                        "term": {"Spinocerebellar ataxia 1": 1}
+                    },
+                    "individuals": {
+                        "age": {"40": 1},
+                        "count": 1,
+                        "karyotypic_sex": {
+                            "OTHER_KARYOTYPE": 0,
+                            "UNKNOWN_KARYOTYPE": 1,
+                            "XO": 0,
+                            "XX": 0,
+                            "XXX": 0,
+                            "XXXX": 0,
+                            "XXXY": 0,
+                            "XXY": 0,
+                            "XXYY": 0,
+                            "XY": 0,
+                            "XYY": 0,
+                        },
+                        "sex": {
+                            "FEMALE": 0,
+                            "MALE": 1,
+                            "OTHER_SEX": 0,
+                            "UNKNOWN_SEX": 0,
+                        },
+                        "taxonomy": {},
+                    },
+                    "phenotypic_features": {
+                        "count": 1,
+                        "type": {"Proptosis": 3},
+                    },
+                },
+            },
+            "experiment": {
+                "count": 1,
+                "data_type_specific": {
+                    "experiment_results": {
+                        "count": 0,
+                        "data_output_type": {},
+                        "file_format": {},
+                        "usage": {}
+                    },
+                    "experiments": {
+                        "count": 1,
+                        "experiment_type": {"DNA Methylation": 1},
+                        "extraction_protocol": {"NGS": 1},
+                        "library_layout": {"Single": 1},
+                        "library_selection": {"PCR": 1},
+                        "library_source": {"Genomic": 1},
+                        "library_strategy": {"Bisulfite-Seq": 1},
+                        "molecule": {"total RNA": 1},
+                        "study_type": {"Whole genome Sequencing": 1}
+                    },
+                    "instruments": {
+                        "count": 0,
+                        "model": {},
+                        "platform": {}
+                    }
+                },
+            }
+        })
 
     def test_dataset_summary_not_a_uuid(self):
         r = self.dt_authz_full_get(reverse("chord-dataset-summary", kwargs={"dataset_id": "not-a-uuid"}))

--- a/chord_metadata_service/chord/views_search.py
+++ b/chord_metadata_service/chord/views_search.py
@@ -524,4 +524,4 @@ async def dataset_summary(request: DrfRequest, dataset_id: str):
              DATASET_DATA_TYPE_SUMMARY_FUNCTIONS.keys())
     )
 
-    return Response({dt: s} for dt, s in zip(DATASET_DATA_TYPE_SUMMARY_FUNCTIONS.keys(), summaries))
+    return Response({dt: s for dt, s in zip(DATASET_DATA_TYPE_SUMMARY_FUNCTIONS.keys(), summaries)})


### PR DESCRIPTION
was supposed to be a dictionary of {data type: summary}, ended up accidentally as [{data type 1: sumary}, {data type 2: summary}]
also adds a test for response format for the dataset summary endpoint to prevent this from happening again in the future.

should fix web dataset data type summaries in manager.