### PR TITLE
chore: publish json schemas as release artifacts

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,3 +33,16 @@ jobs:
           image-name: ghcr.io/bento-platform/katsu
           development-dockerfile: bento.dev.Dockerfile
           dockerfile: bento.Dockerfile
+
+      # TODO: test, maybe just add to a protected build directory?
+      - name: Make release artifacts
+        run: |
+          ./manage.py schema phenopacket >> ./dist/schemas/phenopacket_schema.json
+          ./manage.py schema experiment >> ./dist/schemas/experiment_schema.json
+          ./manage.py schema discovery >> ./dist/schemas/discovery.json
+
+      - name: Upload release artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: JSON-schemas
+          path: ./dist/schemas

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,17 +33,3 @@ jobs:
           image-name: ghcr.io/bento-platform/katsu
           development-dockerfile: bento.dev.Dockerfile
           dockerfile: bento.Dockerfile
-
-      # TODO: test, maybe just add to a protected build directory?
-      - name: Make release artifacts
-        run: |
-          mkdir -p ./dist/schemas
-          ./manage.py schema phenopacket >> ./dist/schemas/phenopacket_schema.json
-          ./manage.py schema experiment >> ./dist/schemas/experiment_schema.json
-          ./manage.py schema discovery >> ./dist/schemas/discovery.json
-
-      - name: Upload release artifacts
-        uses: actions/upload-artifact@v4
-        with:
-          name: JSON-schemas
-          path: ./dist/schemas

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,6 +37,7 @@ jobs:
       # TODO: test, maybe just add to a protected build directory?
       - name: Make release artifacts
         run: |
+          mkdir -p ./dist/schemas
           ./manage.py schema phenopacket >> ./dist/schemas/phenopacket_schema.json
           ./manage.py schema experiment >> ./dist/schemas/experiment_schema.json
           ./manage.py schema discovery >> ./dist/schemas/discovery.json

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,11 +2,6 @@ name: Create and upload release artifacts
 on:
   release:
     types: [published, prereleased]
-  # temporary PR trigger for test
-  pull_request:
-    branches:
-      - develop
-      - 'features/**'
 
 jobs:
   release-artifacts:
@@ -43,21 +38,19 @@ jobs:
           script: |
             const fs = require("fs");
 
-            // temporary hardcoding for test
-            const tag = "v8.0.2-test";
-            // const tag = context.ref.replace("refs/tags/", "");
-            console.log("tag = ", tag);
+            // get tag
+            const tag = context.ref.replace("refs/tags/", "");
 
+            // get release from tag
             const release = await github.rest.repos.getReleaseByTag({
               owner: context.repo.owner,
               repo: context.repo.repo,
               tag: tag,
             });
-            console.log("release id = ", release.data.id)
             await github.rest.repos.uploadReleaseAsset({
               owner: context.repo.owner,
               repo: context.repo.repo,
               release_id: release.data.id,
-              name: "json-schemas-clean.zip",
+              name: "json-schemas.zip",
               data: await fs.readFileSync("./json-schemas.zip"),
             });

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,7 +38,7 @@ jobs:
         uses: actions/github-script@v7
         with:
           script: |
-            const fs = require(fs);
+            const fs = require("fs");
 
             // temporary hardcoding for test
             const tag = "v8.0.2-test";

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,59 @@
+name: Create and upload release artifacts
+on:
+  release:
+    types: [published, prereleased]
+  # temporary PR trigger for test
+  pull_request:
+    branches:
+      - develop
+      - 'features/**'
+
+jobs:
+  release-artifacts:
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+    
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          submodules: true
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - name: Install Poetry
+        run: python -m pip install poetry
+      - name: Install dependencies
+        run: poetry install
+      - name: Make release artifacts
+        run: |
+          mkdir -p ./dist/schemas
+          ./manage.py schema phenopacket >> ./dist/schemas/phenopacket_schema.json
+          ./manage.py schema experiment >> ./dist/schemas/experiment_schema.json
+          ./manage.py schema discovery >> ./dist/schemas/discovery.json
+      - name: Upload release artifacts
+        uses: actions/github-scripts@v7
+        with:
+          script: |
+            const fs = require(fs);
+
+            # temporary hardcoding for test
+            const tag = "v8.0.2-test"
+            # const tag = context.ref.replace("refs/tags/", "");
+            console.log("tag = ", tag);
+
+            const release = await github.rest.repos.getReleaseByTag({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              tag
+            });
+            await github.rest.repos.uploadReleaseAsset({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              release_id: release.data.id,
+              name: "JSON Schemas",
+              data: await fs.readdirSync("./dist/schemas")
+            });

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,9 +31,9 @@ jobs:
       - name: Make release artifacts
         run: |
           mkdir -p ./dist/schemas
-          poetry run ./manage.py schema phenopacket >> ./dist/schemas/phenopacket_schema.json
-          poetry run ./manage.py schema experiment >> ./dist/schemas/experiment_schema.json
-          poetry run ./manage.py schema discovery >> ./dist/schemas/discovery.json
+          poetry run ./manage.py schemas phenopacket >> ./dist/schemas/phenopacket_schema.json
+          poetry run ./manage.py schemas experiment >> ./dist/schemas/experiment_schema.json
+          poetry run ./manage.py schemas discovery >> ./dist/schemas/discovery.json
       - name: Upload release artifacts
         uses: actions/github-script@v7
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,7 +35,7 @@ jobs:
           ./manage.py schema experiment >> ./dist/schemas/experiment_schema.json
           ./manage.py schema discovery >> ./dist/schemas/discovery.json
       - name: Upload release artifacts
-        uses: actions/github-scripts@v7
+        uses: actions/github-script@v7
         with:
           script: |
             const fs = require(fs);

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,6 +35,7 @@ jobs:
           poetry run ./manage.py schemas phenopacket >> ./dist/schemas/phenopacket_schema.json
           poetry run ./manage.py schemas experiment >> ./dist/schemas/experiment_schema.json
           poetry run ./manage.py schemas discovery >> ./dist/schemas/discovery.json
+          zip -r json-schemas.zip ./dist/schemas
       - name: Upload release artifacts
         uses: actions/github-script@v7
         with:
@@ -56,6 +57,6 @@ jobs:
               owner: context.repo.owner,
               repo: context.repo.repo,
               release_id: release.data.id,
-              name: "JSON Schemas",
-              data: await fs.readdirSync("./dist/schemas"),
+              name: "json-schemas.zip",
+              data: await fs.readFile("./json-schemas.zip"),
             });

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,7 +13,8 @@ jobs:
     runs-on: ubuntu-latest
 
     permissions:
-      contents: read
+      contents: write
+      repository-projects: write
     
     steps:
       - name: Checkout

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,7 +35,8 @@ jobs:
           poetry run ./manage.py schemas phenopacket >> ./dist/schemas/phenopacket_schema.json
           poetry run ./manage.py schemas experiment >> ./dist/schemas/experiment_schema.json
           poetry run ./manage.py schemas discovery >> ./dist/schemas/discovery.json
-          zip -r json-schemas.zip ./dist/schemas
+          pushd ./dist/schemas
+          zip -r ../../json-schemas.zip *
       - name: Upload release artifacts
         uses: actions/github-script@v7
         with:
@@ -57,6 +58,6 @@ jobs:
               owner: context.repo.owner,
               repo: context.repo.repo,
               release_id: release.data.id,
-              name: "json-schemas.zip",
+              name: "json-schemas-clean.zip",
               data: await fs.readFileSync("./json-schemas.zip"),
             });

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -58,5 +58,5 @@ jobs:
               repo: context.repo.repo,
               release_id: release.data.id,
               name: "json-schemas.zip",
-              data: await fs.readFile("./json-schemas.zip"),
+              data: await fs.readFileSync("./json-schemas.zip"),
             });

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,9 +31,9 @@ jobs:
       - name: Make release artifacts
         run: |
           mkdir -p ./dist/schemas
-          ./manage.py schema phenopacket >> ./dist/schemas/phenopacket_schema.json
-          ./manage.py schema experiment >> ./dist/schemas/experiment_schema.json
-          ./manage.py schema discovery >> ./dist/schemas/discovery.json
+          poetry run ./manage.py schema phenopacket >> ./dist/schemas/phenopacket_schema.json
+          poetry run ./manage.py schema experiment >> ./dist/schemas/experiment_schema.json
+          poetry run ./manage.py schema discovery >> ./dist/schemas/discovery.json
       - name: Upload release artifacts
         uses: actions/github-script@v7
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,20 +40,21 @@ jobs:
           script: |
             const fs = require(fs);
 
-            # temporary hardcoding for test
-            const tag = "v8.0.2-test"
-            # const tag = context.ref.replace("refs/tags/", "");
+            // temporary hardcoding for test
+            const tag = "v8.0.2-test";
+            // const tag = context.ref.replace("refs/tags/", "");
             console.log("tag = ", tag);
 
             const release = await github.rest.repos.getReleaseByTag({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              tag
+              tag: tag,
             });
+            console.log("release id = ", release.data.id)
             await github.rest.repos.uploadReleaseAsset({
               owner: context.repo.owner,
               repo: context.repo.repo,
               release_id: release.data.id,
               name: "JSON Schemas",
-              data: await fs.readdirSync("./dist/schemas")
+              data: await fs.readdirSync("./dist/schemas"),
             });

--- a/chord_metadata_service/chord/management/commands/schemas.py
+++ b/chord_metadata_service/chord/management/commands/schemas.py
@@ -1,0 +1,27 @@
+import json
+from typing import Any
+from django.core.management.base import BaseCommand, CommandParser
+
+from chord_metadata_service.chord.data_types import DATA_TYPE_EXPERIMENT, DATA_TYPE_PHENOPACKET
+from chord_metadata_service.discovery.schemas import DISCOVERY_SCHEMA
+from chord_metadata_service.experiments.schemas import EXPERIMENT_SCHEMA
+from chord_metadata_service.phenopackets.schemas import PHENOPACKET_SCHEMA
+
+NAME_TO_SCHEMA: dict[str, object] = {
+  DATA_TYPE_PHENOPACKET: PHENOPACKET_SCHEMA,
+  DATA_TYPE_EXPERIMENT: EXPERIMENT_SCHEMA,
+  "discovery": DISCOVERY_SCHEMA,
+}
+
+class Command(BaseCommand):
+  help = """
+      Compiles and returns a JSON-schema in a single JSON file for artifact.
+      Use in GitHub Actions in order to publish usable schemas on releases.
+  """
+
+  def add_arguments(self, parser: CommandParser) -> None:
+    parser.add_argument("schema", action="store", type=str, choices=NAME_TO_SCHEMA.keys())
+
+  def handle(self, *args: Any, **options: Any) -> str | None:
+    schema = NAME_TO_SCHEMA[options["schema"]]
+    self.stdout.write(json.dumps(schema))

--- a/chord_metadata_service/chord/management/commands/schemas.py
+++ b/chord_metadata_service/chord/management/commands/schemas.py
@@ -25,4 +25,4 @@ class Command(BaseCommand):
 
     def handle(self, *args: Any, **options: Any) -> str | None:
         schema = NAME_TO_SCHEMA[options["schema"]]
-        self.stdout.write(json.dumps(schema))
+        self.stdout.write(json.dumps(schema, indent=2))

--- a/chord_metadata_service/chord/management/commands/schemas.py
+++ b/chord_metadata_service/chord/management/commands/schemas.py
@@ -13,15 +13,16 @@ NAME_TO_SCHEMA: dict[str, object] = {
   "discovery": DISCOVERY_SCHEMA,
 }
 
+
 class Command(BaseCommand):
-  help = """
-      Compiles and returns a JSON-schema in a single JSON file for artifact.
-      Use in GitHub Actions in order to publish usable schemas on releases.
-  """
+    help = """
+        Compiles and returns a JSON-schema in a single JSON file for artifact.
+        Use in GitHub Actions in order to publish usable schemas on releases.
+    """
 
-  def add_arguments(self, parser: CommandParser) -> None:
-    parser.add_argument("schema", action="store", type=str, choices=NAME_TO_SCHEMA.keys())
+    def add_arguments(self, parser: CommandParser) -> None:
+        parser.add_argument("schema", action="store", type=str, choices=NAME_TO_SCHEMA.keys())
 
-  def handle(self, *args: Any, **options: Any) -> str | None:
-    schema = NAME_TO_SCHEMA[options["schema"]]
-    self.stdout.write(json.dumps(schema))
+    def handle(self, *args: Any, **options: Any) -> str | None:
+        schema = NAME_TO_SCHEMA[options["schema"]]
+        self.stdout.write(json.dumps(schema))


### PR DESCRIPTION
- new django manage.py script `schemas` to generate single file JSON-schemas for phenopackets, experiments and discovery
- new `release` github actions workflow is triggered on new releases and adds the schemas to the release as an artifact zip file

Tested with a [dummy](https://github.com/bento-platform/katsu/releases/tag/v8.0.2-test) pre-release with a PR trigger. 
The content of the `json-schemas-clean.zip` artifact is what it will look like on a real release, but with the `json-schemas.zip` name (artifacts cannot be overriden, so I changed the names as I was testing to avoid errors).