### PR TITLE
fix(actions): single release workflow trigger for pre-release and stable

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,7 +1,7 @@
 name: Create and upload release artifacts
 on:
   release:
-    types: [published, prereleased]
+    types: [published]
 
 jobs:
   release-artifacts:


### PR DESCRIPTION
The `published` release type is triggered for both stable and pre-release.
Having both `published` and `prerelease` caused the workflow to run in double on pre-releases.