### PR TITLE
feat(discovery): detailed matches for discovery individual response

### DIFF
--- a/chord_metadata_service/patients/api_views.py
+++ b/chord_metadata_service/patients/api_views.py
@@ -354,6 +354,13 @@ class PublicListIndividuals(APIView):
             authz_middleware.mark_authz_done(request)
             return Response(dres.INSUFFICIENT_DATA_AVAILABLE)
 
+        # filtered_qs: filtered Individual queryset
+        filtered_qs = filtered_qs.annotate(
+            phenopacket_id=F("phenopackets__id"),
+            dataset_id=F("phenopackets__dataset__identifier"),
+            project_id=F("phenopackets__dataset__project__identifier"),
+        )
+
         (tissues_count, sampled_tissues), (experiments_count, experiment_types) = await asyncio.gather(
             individual_biosample_tissue_stats(filtered_qs, discovery, dt_perms_pheno),
             individual_experiment_type_stats(filtered_qs, discovery, dt_perms_exp),
@@ -363,7 +370,28 @@ class PublicListIndividuals(APIView):
         return Response({
             "count": ind_qct,
             # Only if we have "query:data" - this field is for Beacon, which should have an access token:
-            **({"matches": filtered_qs.values_list("id", flat=True)} if perm_pheno_query_data else {}),
+            **(
+                {
+                    "matches": filtered_qs.values_list("id", flat=True),
+                    # Below is a temporary detailed match list so we can start building a better search UI.
+                    "matches_detail": [
+                        {
+                            "id": i.id,
+                            **({
+                                "phenopacket_id": i.phenopacket_id,
+                                "project_id": i.project_id,
+                                "dataset_id": i.dataset_id,
+                            } if i.phenopacket_id else {
+                                "phenopacket_id": None,
+                                "project_id": None,
+                                "dataset_id": None,
+                            })
+                        } async for i in filtered_qs
+                    ],
+                }
+                if perm_pheno_query_data
+                else {}
+            ),
             "biosamples": {
                 "count": tissues_count,
                 "sampled_tissue": sampled_tissues,

--- a/chord_metadata_service/patients/api_views.py
+++ b/chord_metadata_service/patients/api_views.py
@@ -109,6 +109,9 @@ class IndividualViewSet(BentoAuthzScopedModelViewSet):
 
     def list(self, request, *args, **kwargs):
         if request.query_params.get("format") == OUTPUT_FORMAT_BENTO_SEARCH_RESULT:
+            # TODO: this whole thing is badly-placed: it really should be an alternate view of phenopackets, not
+            #  individuals. As such, it can return >1 record for the same individual if they have >1 phenopacket.
+
             scope = async_to_sync(get_request_discovery_scope)(self.request)
 
             start = datetime.now()

--- a/chord_metadata_service/patients/api_views.py
+++ b/chord_metadata_service/patients/api_views.py
@@ -123,9 +123,13 @@ class IndividualViewSet(BentoAuthzScopedModelViewSet):
             qs = (
                 Phenopacket
                 .get_model_scoped_queryset(scope)
+                .prefetch_related("dataset__project")
                 .filter(subject__id__in=individual_ids)
                 .values(
                     "subject_id",
+                    "dataset_id",
+                    phenopacket_id=F("id"),
+                    project_id=F("dataset__project_id"),
                     alternate_ids=Coalesce(F("subject__alternate_ids"), [])
                 )
                 .annotate(

--- a/chord_metadata_service/patients/tests/test_api.py
+++ b/chord_metadata_service/patients/tests/test_api.py
@@ -239,12 +239,22 @@ class IndividualCSVRendererTest(AuthzAPITestCase):
 class IndividualWithPhenopacketSearchTest(AuthzAPITestCase):
     """ Test for api/individuals?search= """
 
+    # params, expected # results, expected result object # keys
     search_test_params = (
         ("search=P49Y", 1, None),
         ("search=NCBITaxon:9606", 2, None),
-        # 5 fields in the bento search response:
-        ("search=P49Y&format=bento_search_result", 1, 5),
-        ("search=NCBITaxon:9606&format=bento_search_result", 1, 5),  # only 1 of the individuals has a phenopacket
+        # 8 fields in the individuals Bento search response
+        # (original Bento search response + dataset/project/phenopacket IDs):
+        #  - subject_id
+        #  - dataset_id
+        #  - project_id
+        #  - phenopacket_id
+        #  - alternate_ids
+        #  - num_experiments
+        #  - biosamples
+        #  - experiments_with_biosamples
+        ("search=P49Y&format=bento_search_result", 1, 8),
+        ("search=NCBITaxon:9606&format=bento_search_result", 1, 8),  # only 1 of the individuals has a phenopacket
     )
 
     def setUp(self):
@@ -532,6 +542,7 @@ class PublicFilteringIndividualsTest(AuthzAPITestCase, ProjectTestCase):
         self.assertDictEqual(response.json(), {
             "count": 0,
             "matches": [],
+            "matches_detail": [],
             "biosamples": {"count": 0, "sampled_tissue": []},
             "experiments": {"count": 0, "experiment_type": []},
         })
@@ -543,6 +554,7 @@ class PublicFilteringIndividualsTest(AuthzAPITestCase, ProjectTestCase):
         self.assertDictEqual(response.json(), {
             "count": 0,
             "matches": [],
+            "matches_detail": [],
             "biosamples": {"count": 0, "sampled_tissue": []},
             "experiments": {"count": 0, "experiment_type": []},
         })

--- a/chord_metadata_service/patients/tests/test_api.py
+++ b/chord_metadata_service/patients/tests/test_api.py
@@ -253,8 +253,9 @@ class IndividualWithPhenopacketSearchTest(AuthzAPITestCase):
         #  - num_experiments
         #  - biosamples
         #  - experiments_with_biosamples
-        ("search=P49Y&format=bento_search_result", 1, 8),
-        ("search=NCBITaxon:9606&format=bento_search_result", 1, 8),  # only 1 of the individuals has a phenopacket
+        # only 1 of the individuals has any phenopackets (2):
+        ("search=P49Y&format=bento_search_result", 2, 8),
+        ("search=NCBITaxon:9606&format=bento_search_result", 2, 8),
     )
 
     def setUp(self):
@@ -263,6 +264,9 @@ class IndividualWithPhenopacketSearchTest(AuthzAPITestCase):
         self.metadata_1 = ph_m.MetaData.objects.create(**ph_c.VALID_META_DATA_1)
         self.phenopacket_1 = ph_m.Phenopacket.objects.create(
             **ph_c.valid_phenopacket(subject=self.individual_one, meta_data=self.metadata_1)
+        )
+        self.phenopacket_2 = ph_m.Phenopacket.objects.create(
+            **ph_c.valid_phenopacket(subject=self.individual_one, meta_data=self.metadata_1, id="phenopacket:2")
         )
 
     def test_search(self):  # test full-text search (standard + bento search format)
@@ -285,7 +289,7 @@ class IndividualWithPhenopacketSearchTest(AuthzAPITestCase):
         get_resp = self.one_authz_get(f"/api/individuals/{self.individual_one.id}/phenopackets")
         self.assertEqual(get_resp.status_code, status.HTTP_200_OK)
         response_obj_1 = get_resp.json()
-        self.assertEqual(len(response_obj_1), 1)  # 1 phenopacket for individual
+        self.assertEqual(len(response_obj_1), 2)  # 2 phenopackets for individual
 
     def test_individual_phenopackets_forbidden(self):
         get_resp = self.one_no_authz_get(f"/api/individuals/{self.individual_one.id}/phenopackets")
@@ -296,7 +300,7 @@ class IndividualWithPhenopacketSearchTest(AuthzAPITestCase):
         self.assertEqual(post_resp.status_code, status.HTTP_200_OK)
         self.assertIn("attachment; filename=", post_resp.headers.get("Content-Disposition", ""))
         response_obj_2 = post_resp.json()
-        self.assertEqual(len(response_obj_2), 1)  # 1 phenopacket for individual, still
+        self.assertEqual(len(response_obj_2), 2)  # 2 phenopackets for individual, still
 
     def test_individual_phenopackets_attachment_forbidden(self):
         post_resp = self.one_no_authz_post(f"/api/individuals/{self.individual_one.id}/phenopackets?attachment=1")
@@ -487,19 +491,29 @@ class PublicFilteringIndividualsTest(AuthzAPITestCase, ProjectTestCase):
         ]
 
         individual_objs = [Individual.objects.create(**individual) for individual in self.individuals]
-        biosample = ph_m.Biosample.objects.create(**ph_c.valid_biosample_1(Individual.objects.all()[0]))
+        biosample = ph_m.Biosample.objects.create(**ph_c.valid_biosample_1(individual_objs[0]))
 
         for idx, individual in enumerate(individual_objs, 1):
-            self.meta_data = ph_m.MetaData.objects.create(**ph_c.VALID_META_DATA_1)
-            self.phenopacket = ph_m.Phenopacket.objects.create(
+            meta_data = ph_m.MetaData.objects.create(**ph_c.VALID_META_DATA_1)
+            phenopacket = ph_m.Phenopacket.objects.create(
                 id=f"phenopacket_id:{idx}",
                 subject=individual,
-                meta_data=self.meta_data,
+                meta_data=meta_data,
                 dataset=self.dataset,
             )
             if idx == 1:
-                self.phenopacket.biosamples.add(biosample)
-                self.phenopacket.save()
+                phenopacket.biosamples.add(biosample)
+                phenopacket.save()
+
+                phenopacket_2 = ph_m.Phenopacket.objects.create(
+                    id=f"phenopacket_id:{idx}-2",
+                    subject=individual,
+                    meta_data=meta_data,
+                    dataset=self.dataset,
+                )
+                biosample_2 = ph_m.Biosample.objects.create(**ph_c.valid_biosample_2(individual))
+                phenopacket_2.biosamples.add(biosample_2)
+                phenopacket_2.save()
 
         instrument = ex_m.Instrument.objects.create(**ex_c.valid_instrument())
         ex_m.Experiment.objects.create(**ex_c.valid_experiment(biosample, instrument, self.dataset, 1))


### PR DESCRIPTION
adds a second matches list object for discovery endpoints to return project/dataset ID and phenopacket ID in addition to subject IDs. this is quasi-temporary, until we can get around to adding an improved search endpoint...