### PR TITLE
fix(chord): discovery config de/serialization in project/dataset endpoints

### DIFF
--- a/chord_metadata_service/chord/serializers.py
+++ b/chord_metadata_service/chord/serializers.py
@@ -23,6 +23,11 @@ LINKED_FIELD_SETS_SCHEMA_VALIDATOR = Draft7Validator(LINKED_FIELD_SETS_SCHEMA)
 
 
 class DiscoveryConfigField(serializers.Field):
+    """
+    Custom field serializer/deserializer for the DiscoveryConfig Pydantic model, used as the value for discovery fields
+    on the Project/Dataset models.
+    """
+
     def to_representation(self, value):
         return value.model_dump(mode="json")
 

--- a/chord_metadata_service/chord/serializers.py
+++ b/chord_metadata_service/chord/serializers.py
@@ -1,6 +1,8 @@
+from bento_lib.discovery import DiscoveryConfig
 from bento_lib.schemas.bento import BENTO_DATA_USE_SCHEMA
 from chord_metadata_service.restapi.serializers import GenericSerializer
 from jsonschema import Draft7Validator, Draft4Validator
+from pydantic import ValidationError as PydValidationError
 from rest_framework import serializers
 from chord_metadata_service.restapi.dats_schemas import get_dats_schema, CREATORS
 from chord_metadata_service.restapi.utils import transform_keys
@@ -20,6 +22,17 @@ BENTO_DATA_USE_SCHEMA_VALIDATOR = Draft7Validator(BENTO_DATA_USE_SCHEMA)
 LINKED_FIELD_SETS_SCHEMA_VALIDATOR = Draft7Validator(LINKED_FIELD_SETS_SCHEMA)
 
 
+class DiscoveryConfigField(serializers.Field):
+    def to_representation(self, value):
+        return value.model_dump(mode="json")
+
+    def to_internal_value(self, data):
+        try:
+            return DiscoveryConfig.model_validate(data)
+        except PydValidationError as e:
+            raise serializers.ValidationError(detail=str(e))
+
+
 #############################################################
 #                                                           #
 #              Project Management  Serializers              #
@@ -28,6 +41,8 @@ LINKED_FIELD_SETS_SCHEMA_VALIDATOR = Draft7Validator(LINKED_FIELD_SETS_SCHEMA)
 
 
 class DatasetSerializer(GenericSerializer):
+    discovery = DiscoveryConfigField(required=False, allow_null=True)
+
     always_include = (
         "description",
         "contact_info",
@@ -130,8 +145,6 @@ class DatasetSerializer(GenericSerializer):
 
         return validation
 
-    n_of_tables = serializers.IntegerField(read_only=True)
-
     class Meta:
         model = Dataset
         fields = '__all__'
@@ -147,12 +160,14 @@ class ProjectJsonSchemaSerializer(GenericSerializer):
 
 class ProjectSerializer(serializers.ModelSerializer):
     # Don't inherit GenericSerializer to not pop empty fields
+
     always_include = (
         "title",
         "description",
         "discovery",
     )
 
+    discovery = DiscoveryConfigField(required=False, allow_null=True)
     datasets = DatasetSerializer(read_only=True, many=True, exclude_when_nested=["project"])
     project_schemas = ProjectJsonSchemaSerializer(read_only=True, many=True)
 

--- a/chord_metadata_service/chord/tests/helpers.py
+++ b/chord_metadata_service/chord/tests/helpers.py
@@ -1,6 +1,7 @@
 from django.db.models import Model
 from django.test import TestCase
 from django.urls import reverse
+from rest_framework import status
 
 from chord_metadata_service.authz.tests.helpers import AuthzAPITestCase
 from chord_metadata_service.chord.models import Dataset, Project
@@ -78,4 +79,5 @@ class AuthzAPITestCaseWithProjectJSON(AuthzAPITestCase):
     def setUp(self) -> None:
         super().setUp()
         r = self.one_authz_post(reverse("project-list"), json=VALID_PROJECT_1)
+        self.assertEqual(r.status_code, status.HTTP_201_CREATED)
         self.project = r.json()

--- a/chord_metadata_service/chord/tests/test_api.py
+++ b/chord_metadata_service/chord/tests/test_api.py
@@ -14,6 +14,7 @@ from .constants import (
 from .helpers import ProjectTestCase, AuthzAPITestCaseWithProjectJSON
 from ..models import Project, Dataset, ProjectJsonSchema
 from chord_metadata_service.authz.tests.helpers import AuthzAPITestCase
+from chord_metadata_service.discovery.tests.constants import DISCOVERY_CONFIG_TEST, DISCOVERY_CONFIG_TEST_DICT
 
 
 class CreateProjectAPITest(AuthzAPITestCase):
@@ -23,6 +24,11 @@ class CreateProjectAPITest(AuthzAPITestCase):
             {
                 "title": "Project 2",
                 "description": "",
+            },
+            {
+                "title": "Project 3",
+                "description": "Lorem",
+                "discovery": DISCOVERY_CONFIG_TEST_DICT,
             }
         ]
 
@@ -35,6 +41,11 @@ class CreateProjectAPITest(AuthzAPITestCase):
             {
                 "title": "aa",  # name must be at least 3 characters
                 "description": "",
+            },
+            {
+                "title": "Project 3",
+                "description": "Lorem",
+                "discovery": [DISCOVERY_CONFIG_TEST_DICT],  # wrapped in list
             }
         ]
 
@@ -88,6 +99,18 @@ class UpdateProjectTest(AuthzAPITestCaseWithProjectJSON):
         r = self.one_no_authz_put(f"/api/projects/{self.project['identifier']}", json=self.update_body)
         self.assertEqual(r.status_code, status.HTTP_403_FORBIDDEN)
 
+    def test_project_discovery_put_get(self):
+        # starting from VALID_PROJECT_1, which is a very basic project without a discovery configuration.
+
+        r = self.one_authz_put(
+            f"/api/projects/{self.project['identifier']}",
+            json={**self.without_times(self.project), "discovery": DISCOVERY_CONFIG_TEST_DICT},
+        )
+        self.assertEqual(r.status_code, status.HTTP_200_OK)
+
+        r = self.one_authz_get(f"/api/projects/{self.project['identifier']}")
+        self.assertDictEqual(r.json()["discovery"], DISCOVERY_CONFIG_TEST.model_dump(mode="json"))
+
 
 class DeleteProjectTest(AuthzAPITestCaseWithProjectJSON):
     def test_delete_project(self):
@@ -118,6 +141,12 @@ class CreateDatasetTest(AuthzAPITestCaseWithProjectJSON):
                 **valid_dataset_1(self.project["identifier"]),
                 "title": "Dataset 3",
                 "dats_file": "{}",  # Valid dats_file JSON string
+            },
+            {
+                **valid_dataset_1(self.project["identifier"]),
+                "title": "Dataset 4",
+                "dats_file": "{}",  # Valid dats_file JSON string
+                "discovery": DISCOVERY_CONFIG_TEST_DICT,
             }
         ]
 
@@ -166,6 +195,17 @@ class CreateDatasetTest(AuthzAPITestCaseWithProjectJSON):
     def test_create_dataset_forbidden(self):
         r = self.one_no_authz_post("/api/datasets", json=self.valid_payloads[0])
         self.assertEqual(r.status_code, status.HTTP_403_FORBIDDEN)
+
+    def test_dataset_discovery_put_get(self):
+        r = self.one_authz_post("/api/datasets", json=valid_dataset_1(self.project["identifier"]))
+        d = r.json()
+        self.assertEqual(r.status_code, status.HTTP_201_CREATED)
+
+        r = self.one_authz_put(f"/api/datasets/{d['identifier']}", json={**d, "discovery": DISCOVERY_CONFIG_TEST_DICT})
+        self.assertEqual(r.status_code, status.HTTP_200_OK)
+
+        r = self.one_authz_get(f"/api/datasets/{d['identifier']}")
+        self.assertDictEqual(r.json()["discovery"], DISCOVERY_CONFIG_TEST.model_dump(mode="json"))
 
     def test_dats(self):
         payload = {**self.dats_valid_payload, 'dats_file': {}}


### PR DESCRIPTION
also adds some tests to prevent something similar from happening in the future.

@gsfk this should hopefully fix the discovery config de/serialization issue and when combined with web should let discovery config saving work again (?)