### PR TITLE
feat(discovery): improve match results completeness + small refact

### DIFF
--- a/chord_metadata_service/discovery/api_views.py
+++ b/chord_metadata_service/discovery/api_views.py
@@ -633,6 +633,7 @@ async def discovery_matches(
     pagination = DiscoveryPagination(page=page, page_size=page_size, total=total_count)
     lg = lg.bind(pagination=pagination.model_dump(mode="json"))
 
+    matches_page: QuerySet
     if page_size > 0:
         matches_page = queryset[page * page_size:(page + 1) * page_size] if page_size > 0 else queryset[:]
     else:

--- a/chord_metadata_service/discovery/api_views.py
+++ b/chord_metadata_service/discovery/api_views.py
@@ -357,6 +357,7 @@ async def get_censored_entity_counts(
     *,
     lg: BoundLogger,
     query: DiscoveryQuery | None = None,
+    qqs: QueryQuerysetsCache | None = None,
     return_raw_counts: Literal[False] = False,
 ) -> EntityCountOrBoolResponse: ...
 
@@ -368,6 +369,7 @@ async def get_censored_entity_counts(
     *,
     lg: BoundLogger,
     query: DiscoveryQuery | None,
+    qqs: QueryQuerysetsCache | None,
     return_raw_counts: Literal[True],
 ) -> tuple[EntityCounts, EntityCountOrBoolResponse]: ...
 
@@ -378,6 +380,7 @@ async def get_censored_entity_counts(
     *,
     lg: BoundLogger,
     query: DiscoveryQuery | None = None,
+    qqs: QueryQuerysetsCache | None = None,
     return_raw_counts: bool = False,
 ) -> EntityCountOrBoolResponse | tuple[EntityCounts, EntityCountOrBoolResponse]:
     """
@@ -403,6 +406,7 @@ async def get_censored_entity_counts(
         dt_permissions: Data type permissions for authorization
         lg: Logger instance for structured logging
         query: Optional discovery query with filters/FTS (defaults to empty query)
+        qqs: An existing instance of QueryQuerysetsCache, if one is available; otherwise, one will be created
         return_raw_counts: If True, return tuple of (raw_counts, censored_counts) for logging
 
     Returns:
@@ -410,8 +414,8 @@ async def get_censored_entity_counts(
         If return_raw_counts=True: Tuple of (raw counts dict, censored counts dict)
     """
     query = query or EMPTY_DISCOVERY_QUERY
+    qqs = qqs or QueryQuerysetsCache(query, scope, dt_permissions, lg)
 
-    qqs = QueryQuerysetsCache(query, scope, dt_permissions, lg)
     counts = await discovery_queryset_entity_counts(qqs)
     censored = await censor_entity_counts(scope, counts, dt_permissions, lg)
 
@@ -488,7 +492,7 @@ async def discovery_endpoint(
     # Get both raw counts (for logging) and censored counts (for response)
     # Uses the same shared implementation as Project/Dataset serializers
     counts, count_or_bools_res = await get_censored_entity_counts(
-        scope, dt_permissions, lg=lg, query=query, return_raw_counts=True
+        scope, dt_permissions, lg=lg, query=query, qqs=qqs, return_raw_counts=True
     )
 
     if (

--- a/chord_metadata_service/discovery/matches.py
+++ b/chord_metadata_service/discovery/matches.py
@@ -32,12 +32,20 @@ __all__ = [
 T = TypeVar("T")
 
 
-async def list_or_manager_to_list(x: list[T] | Manager) -> list[T]:
+async def list_or_manager_to_list(x: list[T] | Manager, prefetch: tuple[str, ...] = ()) -> list[T]:
     """
     Given an object which is either a list of T or an instance of a T manager in an async Django DB context,
     return a list[T].
     """
-    return x if isinstance(x, list) else [y async for y in x.all()]
+
+    if isinstance(x, list):
+        return x
+
+    qs = x.all()
+    if prefetch:
+        qs = qs.prefetch_related(*prefetch)
+
+    return [y async for y in qs]
 
 
 class MatchContext(TypedDict, total=False):
@@ -82,22 +90,25 @@ async def experiment_result_matches(
 
 
 async def experiment_matches(
-    mrm: list[em.Experiment] | Manager,
+    mrm: Manager,
     scope: ValidatedDiscoveryScope,
     dt_permissions: DataTypeDiscoveryPermissions,
     root: bool,
     ctx: MatchContext,
 ) -> list[MatchExperiment]:
     res: list[MatchExperiment] = []
-    for exp in await list_or_manager_to_list(mrm):
+    for exp in await list_or_manager_to_list(mrm, prefetch=("biosample__phenopackets",)):
         # TODO: right now, experiment results are not filtered even if a query is executed on them.
+        phenopacket = (await exp.biosample.phenopackets.afirst()) if exp.biosample else None  # TODO: n+1?
         res.append(
             MatchExperiment(
                 id=str(exp.id),
+                experiment_type=exp.experiment_type,
                 study_type=exp.study_type,
                 results=await experiment_result_matches(
                     exp.experiment_results, scope, dt_permissions, False, {**ctx, "experiment": str(exp.id)}
                 ),
+                phenopacket=str(phenopacket.id) if phenopacket else None,
                 **(dict(
                     project=scope.project_id or str(exp.dataset.project_id),
                     dataset=scope.dataset_id or str(exp.dataset_id)
@@ -192,7 +203,7 @@ async def individual_matches(
 ) -> list[MatchIndividual]:
     res: list[MatchIndividual] = []
 
-    for ind in await list_or_manager_to_list(mrm):
+    for ind in await list_or_manager_to_list(mrm, prefetch=("phenopackets__dataset",)):
         ind_id = str(ind.id)
         # TODO: prefetch all the time, even when not filtering.
         # TODO: return both all phenopackets and matching phenopackets?
@@ -204,7 +215,7 @@ async def individual_matches(
             {**ctx, "individual": ind_id},
         )
 
-        first_phenopacket = await ind.phenopackets.prefetch_related("dataset").afirst()
+        first_phenopacket = await ind.phenopackets.afirst()
 
         res.append(
             MatchIndividual(

--- a/chord_metadata_service/discovery/matches.py
+++ b/chord_metadata_service/discovery/matches.py
@@ -16,7 +16,14 @@ from chord_metadata_service.patients.models import Individual
 from chord_metadata_service.phenopackets import models as pm
 from chord_metadata_service.restapi import api_renderers as apir
 
-from .pydantic_models import MatchBiosample, MatchExperiment, MatchExperimentResult, MatchPhenopacket, MatchIndividual
+from .pydantic_models import (
+    MatchBiosample,
+    MatchExperiment,
+    ExperimentResultIndices,
+    MatchExperimentResult,
+    MatchPhenopacket,
+    MatchIndividual,
+)
 from .scope import ValidatedDiscoveryScope
 
 __all__ = [
@@ -69,11 +76,19 @@ async def experiment_result_matches(
         res.append(
             MatchExperimentResult(
                 id=er.id,
+                identifier=er.identifier,  # TODO: cleanup this across Katsu
+                description=er.description or "",  # TODO: clean up null vs blank?
                 filename=er.filename,
                 url=er.url,
-                indices=er.indices,
+                indices=ExperimentResultIndices.model_validate(er.indices),
+                genome_assembly_id=er.genome_assembly_id,
                 file_format=er.file_format,
-                assembly_id=er.genome_assembly_id,
+                data_output_type=er.data_output_type,
+                usage=er.usage,
+                creation_date=er.creation_date,
+                created_by=er.created_by,
+                extra_properties=er.extra_properties,
+                # ----------------------------------------------------------------------------------------------------
                 **(
                     dict(
                         project=scope.project_id or str(
@@ -136,6 +151,7 @@ async def biosample_matches(
         res.append(
             MatchBiosample(
                 id=str(b.id),
+                individual_id=str(b.individual_id) if b.individual_id else None,
                 phenopacket=p,
                 experiments=(
                     # TODO: prefetch all the time, even when not filtering?

--- a/chord_metadata_service/discovery/matches.py
+++ b/chord_metadata_service/discovery/matches.py
@@ -54,8 +54,6 @@ async def queryset_or_related_manager_to_list(
 
     if isinstance(qs, Manager):
         qs = qs.all()
-    elif not isinstance(qs, QuerySet):
-        raise AssertionError(f"queryset_to_list argument must be QuerySet | RelatedManager | list (got {type(qs)})")
 
     if prefetch:
         qs = qs.prefetch_related(*prefetch)

--- a/chord_metadata_service/discovery/matches.py
+++ b/chord_metadata_service/discovery/matches.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 """
 This file contains functions to build match response lists for the discovery matches endpoint.
 These match lists are built from the match models in the pydantic_models.py file. They are not complete instances of
@@ -6,14 +8,15 @@ Since we have pagination, though, we should probably fetch full record details i
 """
 
 from bento_lib.discovery import DiscoveryEntity
-from django.db.models import Manager
-from typing import Awaitable, Callable, Type, TypeVar, TypedDict
+from django.db.models import QuerySet, Manager
+from typing import Awaitable, Callable, Type, TypeVar, TypedDict, TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from django.db.models.fields.related_descriptors import ManyRelatedManager, RelatedManager
 
 from chord_metadata_service.authz.types import DataTypeDiscoveryPermissions
 from chord_metadata_service.chord.data_types import DATA_TYPE_EXPERIMENT
 from chord_metadata_service.experiments import models as em
-from chord_metadata_service.patients.models import Individual
-from chord_metadata_service.phenopackets import models as pm
 from chord_metadata_service.restapi import api_renderers as apir
 
 from .pydantic_models import (
@@ -39,18 +42,26 @@ __all__ = [
 T = TypeVar("T")
 
 
-async def list_or_manager_to_list(x: list[T] | Manager, prefetch: tuple[str, ...] = ()) -> list[T]:
+async def queryset_or_related_manager_to_list(
+    qs: QuerySet | ManyRelatedManager | RelatedManager,
+    prefetch: tuple[str, ...] = (),
+    select_related: tuple[str, ...] = (),
+) -> list[T]:
     """
-    Given an object which is either a list of T or an instance of a T manager in an async Django DB context,
+    Given an object which is either a QuerySet of T or an instance of a T manager in an async Django DB context,
     return a list[T].
     """
 
-    if isinstance(x, list):
-        return x
+    if isinstance(qs, Manager):
+        qs = qs.all()
+    elif not isinstance(qs, QuerySet):
+        raise AssertionError(f"queryset_to_list argument must be QuerySet | RelatedManager | list (got {type(qs)})")
 
-    qs = x.all()
     if prefetch:
         qs = qs.prefetch_related(*prefetch)
+
+    if select_related:
+        qs = qs.select_related(*select_related)
 
     return [y async for y in qs]
 
@@ -63,7 +74,7 @@ class MatchContext(TypedDict, total=False):
 
 
 async def experiment_result_matches(
-    mrm,
+    mrm: QuerySet,
     scope: ValidatedDiscoveryScope,
     _dt_permissions,
     root: bool,
@@ -105,14 +116,16 @@ async def experiment_result_matches(
 
 
 async def experiment_matches(
-    mrm: Manager,
+    mrm: QuerySet,
     scope: ValidatedDiscoveryScope,
     dt_permissions: DataTypeDiscoveryPermissions,
     root: bool,
     ctx: MatchContext,
 ) -> list[MatchExperiment]:
     res: list[MatchExperiment] = []
-    for exp in await list_or_manager_to_list(mrm, prefetch=("biosample__phenopackets",)):
+    for exp in await queryset_or_related_manager_to_list(
+        mrm, select_related=("biosample",), prefetch=("biosample__phenopackets",)
+    ):
         # TODO: right now, experiment results are not filtered even if a query is executed on them.
         phenopacket = (await exp.biosample.phenopackets.afirst()) if exp.biosample else None  # TODO: n+1?
         res.append(
@@ -134,14 +147,14 @@ async def experiment_matches(
 
 
 async def biosample_matches(
-    mrm: list[pm.Biosample] | Manager,
+    mrm: QuerySet,
     scope: ValidatedDiscoveryScope,
     dt_permissions: DataTypeDiscoveryPermissions,
     root: bool,
     ctx: MatchContext,
 ) -> list[MatchBiosample]:
     res: list[MatchBiosample] = []
-    for b in await list_or_manager_to_list(mrm):
+    for b in await queryset_or_related_manager_to_list(mrm):
         p = (ctx or {}).get("phenopacket")
         ds = scope.dataset_id
         if not p and (p_obj := await b.phenopackets.afirst()):
@@ -173,7 +186,7 @@ async def biosample_matches(
 
 
 async def phenopacket_matches(
-    mrm: list[pm.Phenopacket] | Manager,
+    mrm: QuerySet,
     scope: ValidatedDiscoveryScope,
     dt_permissions: DataTypeDiscoveryPermissions,
     root: bool,
@@ -181,7 +194,7 @@ async def phenopacket_matches(
 ) -> list[MatchPhenopacket]:
     res: list[MatchPhenopacket] = []
 
-    for phe in await list_or_manager_to_list(mrm):
+    for phe in await queryset_or_related_manager_to_list(mrm, select_related=("dataset",)):
         phe_id = str(phe.id)
         s_id = phe.subject_id
         # TODO: prefetch all the time, even when not filtering.
@@ -211,7 +224,7 @@ async def phenopacket_matches(
 
 
 async def individual_matches(
-    mrm: list[Individual] | Manager,
+    mrm: QuerySet,
     scope: ValidatedDiscoveryScope,
     dt_permissions: DataTypeDiscoveryPermissions,
     root: bool,
@@ -219,7 +232,7 @@ async def individual_matches(
 ) -> list[MatchIndividual]:
     res: list[MatchIndividual] = []
 
-    for ind in await list_or_manager_to_list(mrm, prefetch=("phenopackets__dataset",)):
+    for ind in await queryset_or_related_manager_to_list(mrm, prefetch=("phenopackets__dataset",)):
         ind_id = str(ind.id)
         # TODO: prefetch all the time, even when not filtering.
         # TODO: return both all phenopackets and matching phenopackets?
@@ -231,7 +244,7 @@ async def individual_matches(
             {**ctx, "individual": ind_id},
         )
 
-        first_phenopacket = await ind.phenopackets.afirst()
+        first_phenopacket = await ind.phenopackets.get_queryset().select_related("dataset").afirst()
 
         res.append(
             MatchIndividual(
@@ -241,7 +254,7 @@ async def individual_matches(
                     dict(
                         # TODO: put this on Individual itself, i.e., link individual with project/dataset?
                         project=scope.project_id or (
-                            str(first_phenopacket.dataset.project_id) if first_phenopacket.dataset else None
+                            str(first_phenopacket.dataset.project_id) if first_phenopacket.dataset_id else None
                         ),
                         dataset=scope.dataset_id or str(first_phenopacket.dataset_id),
                     ) if root else dict()
@@ -255,7 +268,7 @@ async def individual_matches(
 DISCOVERY_ENTITY_TO_MATCH_FN: dict[
     DiscoveryEntity,
     Callable[
-        [list | Manager, ValidatedDiscoveryScope, DataTypeDiscoveryPermissions, bool, MatchContext],
+        [QuerySet, ValidatedDiscoveryScope, DataTypeDiscoveryPermissions, bool, MatchContext],
         Awaitable[list]
     ]
 ] = {

--- a/chord_metadata_service/discovery/pydantic_models.py
+++ b/chord_metadata_service/discovery/pydantic_models.py
@@ -83,8 +83,11 @@ class MatchExperiment(BaseMatchModel):
     Compact representation of an experiment for returning/rendering search responses.
     """
     id: str = Field(..., title="Experiment ID")
-    study_type: str
+    experiment_type: str = Field(..., title="Experiment Type")
+    study_type: str = Field(..., title="Study Type")
     results: list[MatchExperimentResult]
+    # backlink:
+    phenopacket: str | None = Field(..., title="Phenopacket ID")
 
 
 class MatchBiosample(BaseMatchModel):

--- a/chord_metadata_service/discovery/pydantic_models.py
+++ b/chord_metadata_service/discovery/pydantic_models.py
@@ -3,8 +3,9 @@ import abc
 from bento_lib.discovery import FieldDefinition, OverviewSection, DiscoveryEntity, SearchSection
 from pydantic import BaseModel, Field, RootModel
 from rest_framework.request import Request as DrfRequest
-from typing import TypeAlias
+from typing import TypeAlias, Literal
 
+from chord_metadata_service.experiments.types import ExperimentResultFileFormat
 from .types import EntityCountOrBoolResponse
 
 __all__ = [
@@ -14,6 +15,8 @@ __all__ = [
     "DiscoveryFieldResponse",
     "DiscoveryFieldResponses",
     "BaseMatchModel",
+    "ExperimentResultIndex",
+    "ExperimentResultIndices",
     "MatchExperimentResult",
     "MatchExperiment",
     "MatchBiosample",
@@ -67,15 +70,38 @@ class BaseMatchModel(BaseModel, abc.ABC):
     dataset: str | None = Field(default=None, title="Dataset ID")
 
 
+class ExperimentResultIndex(BaseModel):
+    url: str
+    format: Literal[
+        "BAI",  # BAM index files ( http://samtools.github.io/hts-specs/SAMv1.pdf "BAI" )
+        "BGZF",  # BGZip index files (often .gzi)
+        "CRAI",  # CRAM index files ( https://samtools.github.io/hts-specs/CRAMv3.pdf "CRAM index" )
+        "CSI",  # See http://samtools.github.io/hts-specs/CSIv1.pdf
+        "TABIX",  # See https://samtools.github.io/hts-specs/tabix.pdf
+        "TRIBBLE",
+    ]
+
+
+class ExperimentResultIndices(RootModel):
+    root: list[ExperimentResultIndex]
+
+
+# TODO: just merge this with the main serializer; there's no point in returning a subset -- possibly via drf-pydantic
 class MatchExperimentResult(BaseMatchModel):
     id: int = Field(..., title="Experiment result ID")
-    # TODO: experiments backlink
+    identifier: str = Field(..., title="Experiment result laboratory identifier")
+    description: str = Field(..., title="Description")
     filename: str | None = Field(..., title="File name")
     url: str | None = Field(..., title="URL")
-    # list of experiment_result_file_index objects (see experiments/schemas.py)
-    indices: list[dict] = Field(..., title="Indices")
-    file_format: str | None = Field(..., title="File format")
-    assembly_id: str | None = Field(..., title="Genome assembly ID")
+    indices: ExperimentResultIndices = Field(..., title="Indices")
+    file_format: ExperimentResultFileFormat | None = Field(..., title="File format")
+    data_output_type: Literal["Raw data", "Derived data"] | None = Field(..., title="Data output type")
+    usage: str | None = Field(..., title="Usage")
+    creation_date: str | None = Field(..., title="Creation date")
+    created_by: str | None = Field(..., title="Created by")
+    genome_assembly_id: str | None = Field(..., title="Genome assembly ID")
+    extra_properties: dict = Field(..., title="Extra properties")
+    # TODO: experiments backlink
 
 
 class MatchExperiment(BaseMatchModel):
@@ -97,6 +123,7 @@ class MatchBiosample(BaseMatchModel):
     id: str = Field(..., title="Biosample ID")
     # sampled_tissue: OntologyTerm | None
     # sample_type: OntologyTerm | None
+    individual_id: str | None = Field(..., title="Individual ID")
     phenopacket: str | None = Field(..., title="Phenopacket ID")
     experiments: list[MatchExperiment] | None
 

--- a/chord_metadata_service/discovery/tests/test_api.py
+++ b/chord_metadata_service/discovery/tests/test_api.py
@@ -23,6 +23,7 @@ from chord_metadata_service.phenopackets.tests import constants as ph_c
 from chord_metadata_service.experiments import models as exp_m
 from chord_metadata_service.experiments.tests import constants as exp_c
 
+from chord_metadata_service.restapi.pagination import DEFAULT_PAGE_SIZE
 from chord_metadata_service.restapi.tests.constants import (
     VALID_INDIVIDUALS,
     INDIVIDUALS_NOT_ACCEPTED_DATA_TYPES_LIST,
@@ -610,10 +611,7 @@ class DiscoveryMatchesTest(AuthzAPITestCase):
     def test_a_few_json_responses_phenopackets(self):
         p, d, individuals, phenopackets = make_two_individuals_with_phenopackets()
 
-        res = self.dt_authz_full_get(self.url)
-        self.assertEqual(res.status_code, status.HTTP_200_OK)
-
-        self.assertDictEqual(res.json(), {
+        full_res = {
             "results_entity": "phenopacket",
             "results": [
                 {
@@ -621,6 +619,7 @@ class DiscoveryMatchesTest(AuthzAPITestCase):
                     "subject": str(individuals[0].id),
                     "biosamples": [{
                         "id": str(phenopackets[0].biosamples.first().id),
+                        "individual_id": str(phenopackets[0].subject_id),
                         "experiments": [],
                         "phenopacket": str(phenopackets[0].id),
                     }],
@@ -632,6 +631,7 @@ class DiscoveryMatchesTest(AuthzAPITestCase):
                     "subject": str(individuals[1].id),
                     "biosamples": [{
                         "id": str(phenopackets[1].biosamples.first().id),
+                        "individual_id": str(phenopackets[1].subject_id),
                         "experiments": [],
                         "phenopacket": str(phenopackets[1].id),
                     }],
@@ -644,7 +644,19 @@ class DiscoveryMatchesTest(AuthzAPITestCase):
                 "page_size": 25,
                 "total": 2,
             },
-        })
+        }
+
+        full_response_page_sizes = [None, 2, 25, 0]  # page sizes
+
+        for page_size in full_response_page_sizes:
+            with self.subTest(params=(page_size,)):
+                res = self.dt_authz_full_get(
+                    f"{self.url}?_page_size={page_size}" if page_size is not None else self.url
+                )
+                self.assertEqual(res.status_code, status.HTTP_200_OK)
+                expected_res = deepcopy(full_res)
+                expected_res["pagination"]["page_size"] = page_size if page_size is not None else DEFAULT_PAGE_SIZE
+                self.assertDictEqual(res.json(), expected_res)
 
     @override_settings(CONFIG_PUBLIC=DISCOVERY_CONFIG_TEST)
     def test_a_few_json_responses_phenopackets_pagination(self):
@@ -661,6 +673,7 @@ class DiscoveryMatchesTest(AuthzAPITestCase):
                     "subject": str(individuals[1].id),
                     "biosamples": [{
                         "id": str(phenopackets[1].biosamples.first().id),
+                        "individual_id": str(phenopackets[1].subject_id),
                         "experiments": [],
                         "phenopacket": str(phenopackets[1].id),
                     }],
@@ -691,6 +704,7 @@ class DiscoveryMatchesTest(AuthzAPITestCase):
                         {
                             "biosamples": [{
                                 "id": str(phenopackets[1].biosamples.first().id),
+                                "individual_id": str(phenopackets[1].subject_id),
                                 "experiments": [],
                                 "phenopacket": str(phenopackets[1].id),
                             }],
@@ -707,6 +721,7 @@ class DiscoveryMatchesTest(AuthzAPITestCase):
                         {
                             "biosamples": [{
                                 "id": str(phenopackets[0].biosamples.first().id),
+                                "individual_id": str(phenopackets[0].subject_id),
                                 "experiments": [],
                                 "phenopacket": str(phenopackets[0].id),
                             }],

--- a/chord_metadata_service/experiments/types.py
+++ b/chord_metadata_service/experiments/types.py
@@ -1,0 +1,9 @@
+from typing import Literal, TypeAlias
+
+__all__ = ["ExperimentResultFileFormat"]
+
+ExperimentResultFileFormat: TypeAlias = Literal[
+    "SAM", "BAM", "CRAM", "VCF", "BCF", "MAF", "GVCF", "BigWig", "BigBed", "FASTA", "FASTQ", "TAB",
+    "SRA", "SRF", "SFF", "GFF", "PDF", "CSV", "TSV", "JPEG", "PNG", "GIF", "HTML", "MARKDOWN",
+    "MP3", "M4A", "MP4", "DOCX", "XLS", "XLSX", "UNKNOWN", "OTHER",
+]


### PR DESCRIPTION
requesting code review + making sure matches still works as intended.

* adds a bunch of fields to the experiment result response from matches for use in Bento Public (basically just recreating the model in Pydantic at this point I realize; would be good to merge all of these model definitions or just use DRF serializers even though they're terrible perf-wise)
* fixes some weird edge cases with the Django ORM + fixes some related type hinting
* refactors some code added in a prev PR to re-use the query querysets cache object