### PR TITLE
refact(discovery): QueryHelper with counts utils + nested field censoring

### DIFF
--- a/chord_metadata_service/chord/utils.py
+++ b/chord_metadata_service/chord/utils.py
@@ -4,7 +4,7 @@ from structlog.stdlib import BoundLogger
 
 from chord_metadata_service.discovery.scope import ValidatedDiscoveryScope
 from chord_metadata_service.discovery.types import EntityCountOrBoolResponse
-from chord_metadata_service.discovery.api_views import get_censored_entity_counts
+from chord_metadata_service.discovery.api_views import QueryHelper
 from chord_metadata_service.discovery.utils import get_discovery_data_type_permissions
 
 
@@ -32,7 +32,7 @@ async def get_censored_counts_for_serializer(
 
     try:
         dt_permissions = await get_discovery_data_type_permissions(request, scope)
-        return await get_censored_entity_counts(scope, dt_permissions, lg=lg, query=None)
+        return await QueryHelper(None, scope, dt_permissions, lg).get_censored_entity_counts()
     except Exception as e:
         lg.warning(
             "Failed to compute entity counts for serializer, returning empty dict",

--- a/chord_metadata_service/discovery/api_views.py
+++ b/chord_metadata_service/discovery/api_views.py
@@ -71,7 +71,7 @@ is_not_none = partial(is_not, None)
 
 QueryExecutionResult = tuple[QuerySet, frozenset[DiscoveryEntity]]
 
-EMPTY_DISCOVERY_QUERY = DiscoveryQuery(fts=None, filters={})
+EMPTY_DISCOVERY_QUERY = DiscoveryQuery()
 
 
 class QueryHelper:
@@ -152,7 +152,7 @@ class QueryHelper:
 
         fts_queried_entities = frozenset()
 
-        if fts := self._query.fts:
+        if fts := self._query.fts:  # Execute FTS if self._query.fts is not ""
             # Each entity has a corresponding FTS vector we'll use, but querying using this doesn't query across
             # discovery entity boundaries. In order to get result sets for, e.g., phenopackets (with biosamples being
             # the entity with actual FTS matches), we need to build a query for the queryset checking nested biosamples

--- a/chord_metadata_service/discovery/api_views.py
+++ b/chord_metadata_service/discovery/api_views.py
@@ -23,7 +23,6 @@ from typing import Any, Awaitable, Callable, Literal, overload
 from chord_metadata_service.authz.middleware import authz_middleware
 from chord_metadata_service.authz.permissions import BentoAllowAny, BentoDeferToHandler
 from chord_metadata_service.authz.types import DataPermissions, DataTypeDiscoveryPermissions
-from chord_metadata_service.chord import data_types as dts
 from chord_metadata_service.discovery.scope import ValidatedDiscoveryScope
 from chord_metadata_service.logger import logger
 from chord_metadata_service.restapi.api_renderers import PassThruCSVRenderer
@@ -31,7 +30,7 @@ from chord_metadata_service.restapi.pagination import DEFAULT_PAGE_SIZE, DEFAULT
 from chord_metadata_service.utils import build_id_set
 
 from . import responses as dres
-from .censorship import get_rules, thresholded_count, censor_entity_counts
+from .censorship import get_rules, censor_entity_counts
 from .constants import DISCOVERY_ENTITIES
 from .exceptions import DiscoveryScopeException
 from .field_paths.resolve import resolve_filter_mapping_to_queryset_model
@@ -75,21 +74,26 @@ QueryExecutionResult = tuple[QuerySet, frozenset[DiscoveryEntity]]
 EMPTY_DISCOVERY_QUERY = DiscoveryQuery(fts=None, filters={})
 
 
-class QueryQuerysetsCache:
+class QueryHelper:
     """
-    Cache definition for a specific query, in the context of a specific request (--> scope, permissions).
-    It takes a bit of effort to build the Django queryset from field definitions/a query object, and there are specific
-    cases were we may be doing this many times, so we might as well re-use the work done.
+    Helper class and caching object for a specific query, in the context of a specific request (--> scope, permissions).
+
+    Justifications:
+     - encapsulate data/methods that operate on (query, scope, dt_permissions).
+     - cache constructed querysets for a particular instance of the above combination:
+         It takes a bit of effort to build the Django queryset from field definitions/a query object, and there are
+         specific cases were we may be doing this many times, so we might as well re-use the work done.
+     - cache intermediate data used during full-text searching
     """
 
     def __init__(
         self,
-        query: DiscoveryQuery,
+        query: DiscoveryQuery | None,
         scope: ValidatedDiscoveryScope,
         dt_permissions: DataTypeDiscoveryPermissions,
         lg: BoundLogger,
     ):
-        self._query: DiscoveryQuery = query
+        self._query: DiscoveryQuery = query or EMPTY_DISCOVERY_QUERY
         self._scope: ValidatedDiscoveryScope = scope
         self._dt_permissions: DataTypeDiscoveryPermissions = dt_permissions
 
@@ -104,7 +108,18 @@ class QueryQuerysetsCache:
         self._fts_cache: dict[tuple[DiscoveryEntity, str], set] = {}
         self._fts_cache_locks = defaultdict(asyncio.Lock)
 
+        # Cache: entity counts for the scope+permissions+query combination; populated by a call to _get_entity_counts
+        self._entity_counts: EntityCounts | None = None
+
         self._logger: BoundLogger = lg
+
+    @property
+    def scope(self) -> ValidatedDiscoveryScope:
+        return self._scope
+
+    @property
+    def dt_permissions(self) -> DataTypeDiscoveryPermissions:
+        return self._dt_permissions
 
     async def _get_fts_ids(self, fts_entity: DiscoveryEntity, query: str, fts_type: FTSType) -> set:
         """
@@ -182,7 +197,7 @@ class QueryQuerysetsCache:
         async with self._queryset_locks[entity]:
             if entity not in self._queryset_cache:
                 await (lg or self._logger).adebug(
-                    "QueryQuerysetsCache executing query",
+                    "QueryHelper executing query",
                     entity=entity,
                     query=self._query,
                     cache_keys=tuple(self._queryset_cache.keys()),
@@ -192,6 +207,83 @@ class QueryQuerysetsCache:
                 )
 
             return self._queryset_cache[entity]
+
+    async def _get_entity_counts(self) -> EntityCounts:
+        """
+        Returns a dictionary of discovery entity counts for a given scope/query context (i.e., a given QueryHelper
+        instance). In other words, for each discovery entity, we'll get a queryset of the query executed on the entity
+        and count the number of matching entities.
+        """
+
+        if self._entity_counts is None:
+            async def _get_entity_count(ee: DiscoveryEntity) -> int:
+                # We cannot re-validate the field against its options here, as it can trip up "invalid options" due to
+                # small cell counts if we're in a nested entity.
+                #  => For example, if we have 10 individuals with 2 biosamples after querying, and our field entity is a
+                #     biosample but our query is on an individual, we may get a small cell count issue through biosample
+                #     but not if we're going through individual (we may have five FEMALE individuals, but only one with
+                #     a biosample).
+                #
+                # We access [0] of the result of get_query_queryset_and_queried_entities because it returns a tuple of
+                # (queryset, frozenset of queried entities), but we only need the former (to get the count).
+                return await (await self.get_query_queryset_and_queried_entities(ee, validate_field=False))[0].acount()
+
+            self._entity_counts = {
+                e: ec
+                for e, ec in zip(
+                    DISCOVERY_ENTITIES,
+                    await asyncio.gather(*(_get_entity_count(e) for e in DISCOVERY_ENTITIES)),
+                )
+            }
+
+        return self._entity_counts
+
+    @overload
+    async def get_censored_entity_counts(self, return_raw_counts: Literal[False] = False) -> EntityCountOrBoolResponse:
+        ...
+
+    @overload
+    async def get_censored_entity_counts(
+        self, return_raw_counts: Literal[True]
+    ) -> tuple[EntityCounts, EntityCountOrBoolResponse]:
+        ...
+
+    async def get_censored_entity_counts(
+        self, return_raw_counts: bool = False,
+    ) -> EntityCountOrBoolResponse | tuple[EntityCounts, EntityCountOrBoolResponse]:
+        """
+        Get censored entity counts for a scope with given permissions, i.e., a given QueryHelper instance.
+
+        This is the shared implementation used by both:
+        - Discovery endpoint (with query filters)
+        - Project/Dataset serializers (without query filters)
+
+        For each 'discovery entity', we generate either:
+         - a count (0/count-if-above-threshold), or
+         - a boolean (count > threshold)
+
+        If phenopacket is 0, don't reveal nested entities exist, otherwise we could get responses like (in the case of
+        one phenopacket with five biosamples): { phenopacket: 0, biosample: 5, ... }
+        ==> do this, plus the same thing for all entities nested inside other entities
+            (phenopacket -> biosample -> experiment -> experiment_result...)
+        TODO: in the future, if we have other options for non-Phenopackets-centric perspectives, this should instead be
+         done in a more dynamic way, starting from the queryset entity.
+
+        Args:
+            return_raw_counts: If True, return tuple of (raw_counts, censored_counts) for logging
+
+        Returns:
+            If return_raw_counts=False: Dictionary mapping entities to censored counts (int) or booleans
+            If return_raw_counts=True: Tuple of (raw counts dict, censored counts dict)
+        """
+
+        counts = await self._get_entity_counts()  # cached if already called once here
+        censored = await censor_entity_counts(self._scope, counts, self._dt_permissions, self._logger)
+
+        if return_raw_counts:
+            return counts, censored
+
+        return censored
 
 
 def get_accepted_formats(request: DrfRequest) -> AcceptedDiscoveryResponseFormats:
@@ -322,17 +414,18 @@ async def discovery_search_fields(
 
 
 async def discovery_field_response(
-    qqs: QueryQuerysetsCache,
-    scope: ValidatedDiscoveryScope,
+    qh: QueryHelper,
     field: str,
-    dt_permissions: DataTypeDiscoveryPermissions,
+    censored_counts: EntityCountOrBoolResponse,
     lg: BoundLogger,
 ) -> DiscoveryFieldResponse | None:
     lg = lg.bind(field=field)
 
+    scope = qh.scope
+
     field_props = scope.discovery.fields[field]
     field_entity, field_entity_path = normalize_field_path_true_model(*field_props.get_entity_and_field_path())
-    field_perms: DataPermissions = dt_permissions[DISCOVERY_ENTITY_NAMES_TO_DATA_TYPE[field_entity]]
+    field_perms: DataPermissions = qh.dt_permissions[DISCOVERY_ENTITY_NAMES_TO_DATA_TYPE[field_entity]]
 
     if not field_perms.counts:
         # We cannot compute stats right now for boolean-level responses. Thus, if we do not have at least counts
@@ -341,12 +434,19 @@ async def discovery_field_response(
         # this with relative grace (not show a chart/search field, ...).
         return None
 
+    if not censored_counts[field_entity]:
+        # We can have counts above the threshold for the field entity that then must get censored because a parent
+        # entity is being censored due to low counts. For example, with # phenopackets = 3 and # biosamples = 7, the
+        # latter clears the censorship threshold but indirectly reveals the presence of phenopackets, so they both must
+        # be censored to 0/False.
+        return None
+
     # We cannot re-validate the field against its options here, as it can trip up "invalid options" due to small cell
     # counts if we're in a nested entity.
     #  => For example, if we have 10 individuals with 2 biosamples after querying, and our field entity is a
     #     biosample but our query is on an individual, we may get a small cell count issue through biosample but not if
     #     we're going through individual (we may have five FEMALE individuals, but only one with a biosample).
-    queryset, _ = await qqs.get_query_queryset_and_queried_entities(field_entity, lg, validate_field=False)
+    queryset, _ = await qh.get_query_queryset_and_queried_entities(field_entity, lg, validate_field=False)
 
     stats: BinList
 
@@ -368,108 +468,6 @@ async def discovery_field_response(
         return None
 
     return DiscoveryFieldResponse(id=field, definition=field_props, data=stats)
-
-
-async def discovery_queryset_entity_counts(qqs: QueryQuerysetsCache) -> EntityCounts:
-    """
-    Returns a dictionary of discovery entity counts for a given scope/query context (i.e., a given QueryQuerysetsCache
-    instance). In other words, for each discovery entity, we'll get a queryset of the query executed on the entity and
-    count the number of matching entities.
-    """
-
-    async def _get_entity_count(ee: DiscoveryEntity) -> int:
-        # We cannot re-validate the field against its options here, as it can trip up "invalid options" due to small
-        # cell counts if we're in a nested entity.
-        #  => For example, if we have 10 individuals with 2 biosamples after querying, and our field entity is a
-        #     biosample but our query is on an individual, we may get a small cell count issue through biosample but not
-        #     if we're going through individual (we may have five FEMALE individuals, but only one with a biosample).
-        #
-        # We access [0] of the result of get_query_queryset_and_queried_entities because it returns a tuple of
-        # (queryset, frozenset of queried entities), but we only need the former (to get the count).
-        return await (await qqs.get_query_queryset_and_queried_entities(ee, validate_field=False))[0].acount()
-
-    return {
-        e: ec
-        for e, ec in zip(
-            DISCOVERY_ENTITIES,
-            await asyncio.gather(*(_get_entity_count(e) for e in DISCOVERY_ENTITIES)),
-        )
-    }
-
-
-@overload
-async def get_censored_entity_counts(
-    scope: ValidatedDiscoveryScope,
-    dt_permissions: DataTypeDiscoveryPermissions,
-    *,
-    lg: BoundLogger,
-    query: DiscoveryQuery | None = None,
-    qqs: QueryQuerysetsCache | None = None,
-    return_raw_counts: Literal[False] = False,
-) -> EntityCountOrBoolResponse: ...
-
-
-@overload
-async def get_censored_entity_counts(
-    scope: ValidatedDiscoveryScope,
-    dt_permissions: DataTypeDiscoveryPermissions,
-    *,
-    lg: BoundLogger,
-    query: DiscoveryQuery | None,
-    qqs: QueryQuerysetsCache | None,
-    return_raw_counts: Literal[True],
-) -> tuple[EntityCounts, EntityCountOrBoolResponse]: ...
-
-
-async def get_censored_entity_counts(
-    scope: ValidatedDiscoveryScope,
-    dt_permissions: DataTypeDiscoveryPermissions,
-    *,
-    lg: BoundLogger,
-    query: DiscoveryQuery | None = None,
-    qqs: QueryQuerysetsCache | None = None,
-    return_raw_counts: bool = False,
-) -> EntityCountOrBoolResponse | tuple[EntityCounts, EntityCountOrBoolResponse]:
-    """
-    Get censored entity counts for a scope with given permissions.
-
-    This is the shared implementation used by both:
-    - Discovery endpoint (with query filters)
-    - Project/Dataset serializers (without query filters)
-
-    For each 'discovery entity', we generate either:
-     - a count (0/count-if-above-threshold), or
-     - a boolean (count > threshold)
-
-    If phenopacket is 0, don't reveal nested entities exist, otherwise we could get responses like (in the case of
-    one phenopacket with five biosamples): { phenopacket: 0, biosample: 5, ... }
-    ==> do this, plus the same thing for all entities nested inside other entities
-        (phenopacket -> biosample -> experiment -> experiment_result...)
-    TODO: in the future, if we have other options for non-Phenopackets-centric perspectives, this should instead be
-     done in a more dynamic way, starting from the queryset entity.
-
-    Args:
-        scope: Validated discovery scope (project/dataset)
-        dt_permissions: Data type permissions for authorization
-        lg: Logger instance for structured logging
-        query: Optional discovery query with filters/FTS (defaults to empty query)
-        qqs: An existing instance of QueryQuerysetsCache, if one is available; otherwise, one will be created
-        return_raw_counts: If True, return tuple of (raw_counts, censored_counts) for logging
-
-    Returns:
-        If return_raw_counts=False: Dictionary mapping entities to censored counts (int) or booleans
-        If return_raw_counts=True: Tuple of (raw counts dict, censored counts dict)
-    """
-    query = query or EMPTY_DISCOVERY_QUERY
-    qqs = qqs or QueryQuerysetsCache(query, scope, dt_permissions, lg)
-
-    counts = await discovery_queryset_entity_counts(qqs)
-    censored = await censor_entity_counts(scope, counts, dt_permissions, lg)
-
-    if return_raw_counts:
-        return counts, censored
-
-    return censored
 
 
 @api_view(["GET"])
@@ -497,7 +495,7 @@ async def discovery_endpoint(
     # their respective DATA TYPES) queried. Thus, if we're querying, the above check IS NOT SUFFICIENT!
     #  --> this actual second permissions check happens inside the following function stack right now, and raises a
     #      ValidationError:
-    #        QueryQuerysetsCache
+    #        QueryHelper
     #         --> _execute_discovery_query
     #         --> discovery_filter_queryset
     #         --> the overall_permissions.bool_ check
@@ -507,8 +505,9 @@ async def discovery_endpoint(
     try:
         query = DiscoveryQuery.from_drf_request(request)
         lg = lg.bind(queried_entity=queryset_entity, query=query.model_dump(mode="json"))
-        qqs = QueryQuerysetsCache(query, scope, dt_permissions, lg)
-        queryset, queried_entities = await qqs.get_query_queryset_and_queried_entities(queryset_entity)
+        qh = QueryHelper(query, scope, dt_permissions, lg)
+        queryset, queried_entities = await qh.get_query_queryset_and_queried_entities(queryset_entity)
+        censored_counts = await qh.get_censored_entity_counts()  # to be used for censoring field responses!
     except ValidationError as e:
         return await dres.django_validation_error(request, e, lg, "discovery endpoint encountered validation error")
 
@@ -521,12 +520,7 @@ async def discovery_endpoint(
         field: field_res
         for field, field_res in zip(
             fields,
-            await asyncio.gather(
-                *(
-                    discovery_field_response(qqs, scope, field, dt_permissions, lg)
-                    for field in fields
-                )
-            )
+            await asyncio.gather(*(discovery_field_response(qh, field, censored_counts, lg) for field in fields))
         )
         if field_res is not None
         # Parallel async collection of field responses for public overview
@@ -538,9 +532,7 @@ async def discovery_endpoint(
 
     # Get both raw counts (for logging) and censored counts (for response)
     # Uses the same shared implementation as Project/Dataset serializers
-    counts, count_or_bools_res = await get_censored_entity_counts(
-        scope, dt_permissions, lg=lg, query=query, qqs=qqs, return_raw_counts=True
-    )
+    counts, count_or_bools_res = await qh.get_censored_entity_counts(return_raw_counts=True)
 
     if (
         not count_or_bools_res[queryset_entity]
@@ -590,7 +582,7 @@ async def discovery_matches(
       dataset:    Discovery scope - dataset ID (if not set, the project or global scope is used)
 
     Note on query parameter names:
-      - QueryQuerysetsCache._execute_discovery_query calls build_discovery_query_from_request, which grabs every query
+      - QueryHelper._execute_discovery_query calls build_discovery_query_from_request, which grabs every query
         parameter except "project", "dataset", and those starting with "_" and tries to find fields to query.
         By separating the namespace for discovery filter query parameters from "other" query parameters by prefixing
         other query parameters with _, we eliminate possible ambiguities between discovery fields.
@@ -632,15 +624,7 @@ async def discovery_matches(
 
     lg = lg.bind(response_format=response_format)
 
-    # -- Permissions check ---------------------------------------------------------------------------------------------
-
-    if not dt_permissions[dts.DATA_TYPE_PHENOPACKET].data:
-        # "Extra" permissions check vs. regular discovery endpoint: we need full data permissions
-        return dres.insufficient_privileges(request, accepted_formats)
-
-    authz_middleware.mark_authz_done(request)
-
-    # -- Query execution -----------------------------------------------------------------------------------------------
+    # -- Queried entity: grab from query parameters + validate ---------------------------------------------------------
 
     queried_entity: DiscoveryEntity = request.query_params.get("_entity", "phenopacket")
     if queried_entity not in DISCOVERY_ENTITIES:
@@ -648,10 +632,21 @@ async def discovery_matches(
 
     lg = lg.bind(queried_entity=queried_entity)
 
+    # -- Permissions check ---------------------------------------------------------------------------------------------
+
+    if not dt_permissions[DISCOVERY_ENTITY_NAMES_TO_DATA_TYPE[queried_entity]].data:
+        # "Extra" permissions check vs. regular discovery endpoint: we need full data permissions
+        # Since we require query:data here, we don't need to be vigilant about censoring below
+        return dres.insufficient_privileges(request, accepted_formats)
+
+    authz_middleware.mark_authz_done(request)
+
+    # -- Query execution -----------------------------------------------------------------------------------------------
+
     try:
         query = DiscoveryQuery.from_drf_request(request)
-        qqs = QueryQuerysetsCache(query, scope, dt_permissions, lg)
-        queryset, _ = await qqs.get_query_queryset_and_queried_entities(queried_entity)
+        qh = QueryHelper(query, scope, dt_permissions, lg)
+        queryset, _ = await qh.get_query_queryset_and_queried_entities(queried_entity)
         queryset = queryset.order_by("pk")
     except ValidationError as e:
         return await dres.django_validation_error(
@@ -736,18 +731,15 @@ async def discovery_ui_hints(
     """
 
     # TODO: support querying?
-    qqs = QueryQuerysetsCache(EMPTY_DISCOVERY_QUERY, scope, dt_permissions, lg)
-    counts = await discovery_queryset_entity_counts(qqs)
+    qh = QueryHelper(EMPTY_DISCOVERY_QUERY, scope, dt_permissions, lg)
+    counts = await qh.get_censored_entity_counts()
 
     return Response(DiscoveryUIHintsResponse.model_validate({
         # This helps the UI determine which entities are available in a particular scope, so we can hide entities with
         # no data ingested (e.g., not showing experiments for an instance with only phenopackets). Because of this
         # purpose, we don't filter it beforehand - we still want to see 0 counts if they're the result of a specific
         # search, but we don't want them
-        "entities_with_data": [
-            e for e, v in counts.items()
-            if thresholded_count(v, scope, dt_permissions[DISCOVERY_ENTITY_NAMES_TO_DATA_TYPE[e]])
-        ],
+        "entities_with_data": [e for e, v in counts.items() if v],
         # TODO: implement something like this for hinting towards maps
         # TODO: instead of this, maybe we also collect experiment results and check for geojson, and indicate if we
         #  should present a consolidated map view?

--- a/chord_metadata_service/discovery/api_views.py
+++ b/chord_metadata_service/discovery/api_views.py
@@ -111,6 +111,10 @@ class QueryHelper:
         # Cache: entity counts for the scope+permissions+query combination; populated by a call to _get_entity_counts
         self._entity_counts: EntityCounts | None = None
 
+        # Cache: entities with data for the scope (not applying the query);
+        # populated by a call to get_scope_entities_with_data()
+        self._scope_entities_with_data: frozenset[DiscoveryEntity] | None = None
+
         self._logger: BoundLogger = lg
 
     @property
@@ -146,6 +150,8 @@ class QueryHelper:
     ) -> QueryExecutionResult:
         queryset = get_discovery_entity_model_scoped_queryset(queryset_entity, self._scope)
 
+        fts_queried_entities = frozenset()
+
         if fts := self._query.fts:
             # Each entity has a corresponding FTS vector we'll use, but querying using this doesn't query across
             # discovery entity boundaries. In order to get result sets for, e.g., phenopackets (with biosamples being
@@ -166,12 +172,13 @@ class QueryHelper:
             #  - but ONLY when we have specified a scope (project/dataset), I guess due to some kind of prefetching or
             #    join? it's unclear, but for now we just do this ugly thing instead.
             queryset = queryset.filter(fts_filters)
+            fts_queried_entities = await self.get_scope_entities_with_data()
 
         # May raise:
         #  - DiscoveryEmptyException
         #     although in all cases in these API calls this should be mitigated by an initial empty_discovery(...) check
         #  - ValidationError
-        filtered_queryset, queried_entities = await discovery_filter_queryset(
+        filtered_queryset, filter_queried_entities = await discovery_filter_queryset(
             self._scope,
             self._query,
             queryset_entity,
@@ -181,7 +188,7 @@ class QueryHelper:
             validate_field=validate_field,
         )
 
-        return filtered_queryset, queried_entities
+        return filtered_queryset, fts_queried_entities | filter_queried_entities
 
     async def get_query_queryset_and_queried_entities(
         self,
@@ -284,6 +291,23 @@ class QueryHelper:
             return counts, censored
 
         return censored
+
+    async def get_scope_entities_with_data(self) -> frozenset[DiscoveryEntity]:
+        """
+        Gets all discovery entities with data in the current scope, ignoring the query. This helps the logic for
+        "queried entities" with full-text search (FTS), since entities that aren't present in the current scope should
+        not be listed as being queried by the FTS process.
+        """
+
+        if self._scope_entities_with_data is None:
+            if self._query.is_empty():
+                counts = await self.get_censored_entity_counts()
+            else:
+                qh = QueryHelper(EMPTY_DISCOVERY_QUERY, self.scope, self.dt_permissions, self._logger)
+                counts = await qh.get_censored_entity_counts()
+            self._scope_entities_with_data = frozenset((e for e, v in counts.items() if v))
+
+        return self._scope_entities_with_data
 
 
 def get_accepted_formats(request: DrfRequest) -> AcceptedDiscoveryResponseFormats:
@@ -733,19 +757,19 @@ async def discovery_ui_hints(
 
     # TODO: support querying?
     qh = QueryHelper(EMPTY_DISCOVERY_QUERY, scope, dt_permissions, lg)
-    counts = await qh.get_censored_entity_counts()
+    entities_with_data = await qh.get_scope_entities_with_data()
 
-    return Response(DiscoveryUIHintsResponse.model_validate({
+    return Response(DiscoveryUIHintsResponse(
         # This helps the UI determine which entities are available in a particular scope, so we can hide entities with
         # no data ingested (e.g., not showing experiments for an instance with only phenopackets). Because of this
         # purpose, we don't filter it beforehand - we still want to see 0 counts if they're the result of a specific
         # search, but we don't want them
-        "entities_with_data": [e for e, v in counts.items() if v],
+        entities_with_data=entities_with_data,
         # TODO: implement something like this for hinting towards maps
         # TODO: instead of this, maybe we also collect experiment results and check for geojson, and indicate if we
         #  should present a consolidated map view?
         # "biosample_location_present": False,  # TODO: non-Null location_collected above threshold
-    }))
+    ))
 
 
 @api_view(["GET"])

--- a/chord_metadata_service/discovery/api_views.py
+++ b/chord_metadata_service/discovery/api_views.py
@@ -434,11 +434,12 @@ async def discovery_field_response(
         # this with relative grace (not show a chart/search field, ...).
         return None
 
-    if not censored_counts[field_entity]:
+    if not censored_counts[field_entity] and not field_perms.data:
         # We can have counts above the threshold for the field entity that then must get censored because a parent
         # entity is being censored due to low counts. For example, with # phenopackets = 3 and # biosamples = 7, the
         # latter clears the censorship threshold but indirectly reveals the presence of phenopackets, so they both must
         # be censored to 0/False.
+        # Of course, if we have the query:data permission for the field, we can safely reveal the true count.
         return None
 
     # We cannot re-validate the field against its options here, as it can trip up "invalid options" due to small cell

--- a/chord_metadata_service/discovery/pydantic_models.py
+++ b/chord_metadata_service/discovery/pydantic_models.py
@@ -216,6 +216,9 @@ class DiscoveryQuery(BaseModel):
     def queried_filter_fields(self) -> list[str]:
         return list(self.filters.keys())
 
+    def is_empty(self) -> bool:
+        return self.fts is None and len(self.filters) == 0
+
     @classmethod
     def from_drf_request(cls, request: DrfRequest) -> "DiscoveryQuery":
         """
@@ -247,5 +250,5 @@ class DiscoveryUIHintsResponse(BaseModel):
     make the UI nicer by, e.g., selectively hiding parts.
     """
 
-    entities_with_data: list[DiscoveryEntity]
+    entities_with_data: frozenset[DiscoveryEntity]
     # biosample_location_present: bool  TODO

--- a/chord_metadata_service/discovery/pydantic_models.py
+++ b/chord_metadata_service/discovery/pydantic_models.py
@@ -3,7 +3,7 @@ import abc
 from bento_lib.discovery import FieldDefinition, OverviewSection, DiscoveryEntity, SearchSection
 from pydantic import BaseModel, Field, RootModel
 from rest_framework.request import Request as DrfRequest
-from typing import TypeAlias, Literal
+from typing import Literal
 
 from chord_metadata_service.experiments.types import ExperimentResultFileFormat
 from .types import EntityCountOrBoolResponse, FTSType
@@ -145,7 +145,7 @@ class MatchIndividual(BaseMatchModel):
     phenopackets: list[MatchPhenopacket]
 
 
-MatchObject: TypeAlias = (
+type MatchObject = (
     list[MatchPhenopacket] |
     list[MatchIndividual] |
     list[MatchBiosample] |
@@ -203,21 +203,25 @@ class DiscoveryQuery(BaseModel):
     """
 
     # Full text search query + search type. We cap the maximum FTS query length to something reasonable to prevent
-    # unlimited-length queries taking up too much memory with any caching we may do.
+    # unlimited-length queries taking up too much memory with any caching we may do. A blank value for `fts` means no
+    # FTS query will be executed.
     # See:
     #  - https://docs.djangoproject.com/en/5.2/ref/contrib/postgres/search/#searchquery
     #  - https://www.postgresql.org/docs/18/textsearch-controls.html#TEXTSEARCH-PARSING-QUERIES
-    fts: str | None = Field(..., title="Full-text search query", max_length=256)
+    fts: str = Field(default="", title="Full-text search query", max_length=256)
     fts_type: FTSType = Field(default="plain", title="Full-text search query type")
 
     # Filter query parameters. Keys in this dictionary must be the IDs of filters in the corresponding discovery config.
-    filters: dict[str, str]
+    filters: dict[str, str] = Field(default_factory=dict, title="Filters")
 
     def queried_filter_fields(self) -> list[str]:
         return list(self.filters.keys())
 
     def is_empty(self) -> bool:
-        return self.fts is None and len(self.filters) == 0
+        """
+        Returns whether the query instance is equivalent to an empty query.
+        """
+        return not self.fts and len(self.filters) == 0
 
     @classmethod
     def from_drf_request(cls, request: DrfRequest) -> "DiscoveryQuery":
@@ -241,7 +245,7 @@ class DiscoveryQuery(BaseModel):
             # - remove "special" query parameters, which start with "_" (for pagination or other non-filter uses)
         }
 
-        return cls(fts=params.get("_fts") or None, fts_type=params.get("_fts_type") or "plain", filters=filters)
+        return cls(fts=params.get("_fts", ""), fts_type=params.get("_fts_type") or "plain", filters=filters)
 
 
 class DiscoveryUIHintsResponse(BaseModel):

--- a/chord_metadata_service/discovery/scope.py
+++ b/chord_metadata_service/discovery/scope.py
@@ -52,6 +52,12 @@ class ValidatedDiscoveryScope:
         # class MUST NOT be mutated.
         self._discovery: DiscoveryConfig | None = None  # If None, not cached yet
 
+    def __eq__(self, other) -> bool:
+        return isinstance(other, ValidatedDiscoveryScope) and all((
+            (self.project_id is None and other.project_id is None) or self.project_id == other.project_id,
+            (self.dataset_id is None and other.dataset_id is None) or self.dataset_id == other.dataset_id,
+        ))
+
     @property
     def project_id(self) -> str | None:
         """

--- a/chord_metadata_service/discovery/tests/test_api.py
+++ b/chord_metadata_service/discovery/tests/test_api.py
@@ -276,10 +276,9 @@ class DiscoveryOverviewTest(AuthzAPITestCase, ScopedDiscoveryTestCase):
     def assert_scoped_fields(
         self, overview_response: dict, discovery: DiscoveryConfig, expected_fields: set[str] | None = None
     ):
-        self.assertSetEqual(
-            set(field for field in overview_response["fields"].keys()),
-            set(discovery.get_chart_field_ids()) if expected_fields is None else expected_fields,
-        )
+        response_fields = set(field for field in overview_response["fields"].keys())
+        chart_fields = set(discovery.get_chart_field_ids()) if expected_fields is None else expected_fields
+        self.assertSetEqual(response_fields, chart_fields)
 
     def test_empty_discovery(self):
         res = self.dt_authz_full_get(self.url)
@@ -324,8 +323,8 @@ class DiscoveryOverviewTest(AuthzAPITestCase, ScopedDiscoveryTestCase):
             ("?dataset=not-a-uuid", status.HTTP_404_NOT_FOUND, None, None),
         ]
 
-        for params in subtest_params:
-            with self.subTest(params=params):
+        for i, params in enumerate(subtest_params):
+            with self.subTest(params=(i, *params)):
                 qp, expected_status_code, discovery, dts = params
                 url = f"{self.url}{qp}"
 
@@ -347,7 +346,8 @@ class DiscoveryOverviewTest(AuthzAPITestCase, ScopedDiscoveryTestCase):
                     #   no fields have counts permissions, so we don't get any fields back
                     self.assert_scoped_fields(res_json, discovery, expected_fields=set())
 
-                # with counts permissions, we should get the expected status code + (if success) censored counts
+                # with counts permissions, we should get the expected status code + (if success) censored counts, but we
+                # may be missing some fields
 
                 res = self.dt_get("counts", url)
                 self.assertEqual(res.status_code, expected_status_code)
@@ -356,9 +356,16 @@ class DiscoveryOverviewTest(AuthzAPITestCase, ScopedDiscoveryTestCase):
                     res_json = res.json()
                     self.assertIsInstance(res_json, dict)
                     self.assert_counts_censored(res_json, discovery, dts)
+
+                    expected_fields = set(discovery.get_chart_field_ids())
+                    if not res_json["counts"].get("biosample"):
+                        # remove biosample fields from expected response if biosamples censored
+                        expected_fields -= {"tissues", "diagnostic_markers"}
+
                     self.assert_scoped_fields(res_json, discovery)
 
-                # with full permissions, we should get the expected status code + (if success) uncensored counts
+                # with full permissions, we should get the expected status code + (if success) uncensored counts plus
+                # all scoped field responses
 
                 res = self.dt_get("full", url)
                 self.assertEqual(res.status_code, expected_status_code)
@@ -367,14 +374,30 @@ class DiscoveryOverviewTest(AuthzAPITestCase, ScopedDiscoveryTestCase):
                     res_json = res.json()
                     self.assertIsInstance(res_json, dict)
                     self.assert_counts_not_censored(res_json, dts)
-                    self.assert_scoped_fields(res_json, discovery)
+                    self.assert_scoped_fields(res_json, discovery)  # should have all fields, even ones with 0-counts
 
     @override_settings(CONFIG_PUBLIC=DISCOVERY_CONFIG_TEST)
     def test_overview_project_dataset(self):
         # SCOPE: project_a + dataset_a
         response = self.dt_authz_counts_get(f"{self.url}?project={self.id_proj_a}&dataset={self.id_ds_a}")
         self.assertEqual(response.status_code, status.HTTP_200_OK)
-        self.assert_scoped_fields(response.json(), self.dataset_a.discovery)
+        res_json = response.json()
+        discovery = self.dataset_a.discovery
+        # we only have two biosamples, so any fields involving them (tissues, diagnostic_markers) or experiments
+        # (theoretically) gets censored.
+        self.assert_scoped_fields(
+            res_json,
+            discovery,
+            expected_fields=set(discovery.get_chart_field_ids()) - {"tissues", "diagnostic_markers"},
+        )
+        # because we only have two biosamples, counts of biosamples + entities nested under (experiments)
+        self.assertDictEqual(res_json["counts"], {
+            "phenopacket": 8,
+            "individual": 8,
+            "biosample": 0,
+            "experiment": 0,
+            "experiment_result": 0,
+        })
 
         # SCOPE: project_a + dataset_b (invalid)
         response_invalid = self.dt_authz_counts_get(f"{self.url}?project={self.id_proj_a}&dataset={self.id_ds_b}")

--- a/chord_metadata_service/discovery/tests/test_api.py
+++ b/chord_metadata_service/discovery/tests/test_api.py
@@ -358,11 +358,16 @@ class DiscoveryOverviewTest(AuthzAPITestCase, ScopedDiscoveryTestCase):
                     self.assert_counts_censored(res_json, discovery, dts)
 
                     expected_fields = set(discovery.get_chart_field_ids())
+
+                    if not res_json["counts"].get("phenopacket"):
+                        expected_fields -= {"measurement_tumor_length"}
+                    if not res_json["counts"].get("individual"):
+                        expected_fields -= {"age", "sex"}
                     if not res_json["counts"].get("biosample"):
                         # remove biosample fields from expected response if biosamples censored
                         expected_fields -= {"tissues", "diagnostic_markers"}
 
-                    self.assert_scoped_fields(res_json, discovery)
+                    self.assert_scoped_fields(res_json, discovery, expected_fields=expected_fields)
 
                 # with full permissions, we should get the expected status code + (if success) uncensored counts plus
                 # all scoped field responses

--- a/chord_metadata_service/discovery/tests/test_query_helper.py
+++ b/chord_metadata_service/discovery/tests/test_query_helper.py
@@ -14,11 +14,15 @@ class QueryHelperTest(TransactionTestCase):
 
     def setUp(self):
         self.fts_query = DiscoveryQuery(fts="cancer", filters={})
-        self.filters_query = DiscoveryQuery(fts=None, filters={"smoking": "Smoker"})
+        self.filters_query = DiscoveryQuery(fts=None, filters={"sex": "MALE"})
         self.scope = ValidatedDiscoveryScope(project=None, dataset=None)
         self.dt_permissions = {
             DATA_TYPE_PHENOPACKET: DataPermissions(bool_=True, counts=True, data=False),
             DATA_TYPE_EXPERIMENT: DataPermissions(bool_=True, counts=True, data=False),
+        }
+        self.dt_permissions_full = {
+            DATA_TYPE_PHENOPACKET: DataPermissions(bool_=True, counts=True, data=True),
+            DATA_TYPE_EXPERIMENT: DataPermissions(bool_=True, counts=True, data=True),
         }
         self.logger = get_logger("query-helper-test")
 
@@ -33,12 +37,11 @@ class QueryHelperTest(TransactionTestCase):
         qh = QueryHelper(self.fts_query, self.scope, self.dt_permissions, self.logger)
         qs, qe = await qh.get_query_queryset_and_queried_entities("phenopacket")
         # TODO: queried entities for FTS?
-        self.assertEqual(qe, frozenset({"TODO"}))
+        self.assertEqual(qe, frozenset({}))
 
     @override_settings(CONFIG_PUBLIC=DISCOVERY_CONFIG_TEST)
-    async def test_empty_querying_filters(self):
+    async def test_querying_filters_full_perms(self):
         # nothing here
-        qh = QueryHelper(self.filters_query, self.scope, self.dt_permissions, self.logger)
+        qh = QueryHelper(self.filters_query, self.scope, self.dt_permissions_full, self.logger)
         qs, qe = await qh.get_query_queryset_and_queried_entities("phenopacket")
-        print(qs, qe)
         self.assertEqual(qe, frozenset({"individual"}))

--- a/chord_metadata_service/discovery/tests/test_query_helper.py
+++ b/chord_metadata_service/discovery/tests/test_query_helper.py
@@ -1,0 +1,44 @@
+from django.test import TransactionTestCase, override_settings
+from structlog.stdlib import get_logger
+
+from chord_metadata_service.authz.types import DataPermissions
+from chord_metadata_service.chord.data_types import DATA_TYPE_PHENOPACKET, DATA_TYPE_EXPERIMENT
+from chord_metadata_service.discovery.api_views import QueryHelper
+from chord_metadata_service.discovery.pydantic_models import DiscoveryQuery
+from chord_metadata_service.discovery.scope import ValidatedDiscoveryScope
+
+from .constants import DISCOVERY_CONFIG_TEST
+
+
+class QueryHelperTest(TransactionTestCase):
+
+    def setUp(self):
+        self.fts_query = DiscoveryQuery(fts="cancer", filters={})
+        self.filters_query = DiscoveryQuery(fts=None, filters={"smoking": "Smoker"})
+        self.scope = ValidatedDiscoveryScope(project=None, dataset=None)
+        self.dt_permissions = {
+            DATA_TYPE_PHENOPACKET: DataPermissions(bool_=True, counts=True, data=False),
+            DATA_TYPE_EXPERIMENT: DataPermissions(bool_=True, counts=True, data=False),
+        }
+        self.logger = get_logger("query-helper-test")
+
+    def test_property_methods(self):
+        qh = QueryHelper(self.fts_query, self.scope, self.dt_permissions, self.logger)
+        self.assertEqual(qh.scope, self.scope)
+        self.assertEqual(qh.dt_permissions, self.dt_permissions)
+
+    @override_settings(CONFIG_PUBLIC=DISCOVERY_CONFIG_TEST)
+    async def test_empty_querying_fts(self):
+        # nothing here
+        qh = QueryHelper(self.fts_query, self.scope, self.dt_permissions, self.logger)
+        qs, qe = await qh.get_query_queryset_and_queried_entities("phenopacket")
+        # TODO: queried entities for FTS?
+        self.assertEqual(qe, frozenset({"TODO"}))
+
+    @override_settings(CONFIG_PUBLIC=DISCOVERY_CONFIG_TEST)
+    async def test_empty_querying_filters(self):
+        # nothing here
+        qh = QueryHelper(self.filters_query, self.scope, self.dt_permissions, self.logger)
+        qs, qe = await qh.get_query_queryset_and_queried_entities("phenopacket")
+        print(qs, qe)
+        self.assertEqual(qe, frozenset({"individual"}))

--- a/chord_metadata_service/discovery/tests/test_query_helper.py
+++ b/chord_metadata_service/discovery/tests/test_query_helper.py
@@ -14,7 +14,7 @@ class QueryHelperTest(TransactionTestCase):
 
     def setUp(self):
         self.fts_query = DiscoveryQuery(fts="cancer", filters={})
-        self.filters_query = DiscoveryQuery(fts=None, filters={"sex": "MALE"})
+        self.filters_query = DiscoveryQuery(filters={"sex": "MALE"})
         self.scope = ValidatedDiscoveryScope(project=None, dataset=None)
         self.dt_permissions = {
             DATA_TYPE_PHENOPACKET: DataPermissions(bool_=True, counts=True, data=False),

--- a/chord_metadata_service/discovery/tests/test_query_model.py
+++ b/chord_metadata_service/discovery/tests/test_query_model.py
@@ -13,8 +13,10 @@ class TestDiscoveryQueryModel(SimpleTestCase):
     def test_queried_filter_fields(self):
         query = DiscoveryQuery(fts=None, filters={})
         self.assertListEqual(query.queried_filter_fields(), [])
+        self.assertTrue(query.is_empty())
         query = DiscoveryQuery(fts=None, filters={"sex": "MALE", "age": "< 10"})
         self.assertListEqual(query.queried_filter_fields(), ["sex", "age"])
+        self.assertFalse(query.is_empty())
 
     def test_construction_from_get_request(self):
         dr = HttpRequest()
@@ -33,6 +35,7 @@ class TestDiscoveryQueryModel(SimpleTestCase):
         self.assertEqual(fts_q.fts, "'text' | 'text2'")
         self.assertEqual(fts_q.fts_type, "websearch")
         self.assertDictEqual(fts_q.filters, {})
+        self.assertFalse(fts_q.is_empty())
 
         dr = HttpRequest()
         dr.method = "GET"
@@ -41,6 +44,7 @@ class TestDiscoveryQueryModel(SimpleTestCase):
         filter_q = DiscoveryQuery.from_drf_request(DrfRequest(dr))
         self.assertIsNone(filter_q.fts)
         self.assertDictEqual(filter_q.filters, {"sex": "MALE", "age": "< 10"})
+        self.assertFalse(filter_q.is_empty())
 
     @staticmethod
     def _mock_json_post(content: dict | list):

--- a/chord_metadata_service/discovery/tests/test_query_model.py
+++ b/chord_metadata_service/discovery/tests/test_query_model.py
@@ -10,11 +10,21 @@ from ..pydantic_models import DiscoveryQuery
 
 
 class TestDiscoveryQueryModel(SimpleTestCase):
-    def test_queried_filter_fields(self):
-        query = DiscoveryQuery(fts=None, filters={})
+    def test_empty_queries(self):
+        query = DiscoveryQuery()
         self.assertListEqual(query.queried_filter_fields(), [])
         self.assertTrue(query.is_empty())
-        query = DiscoveryQuery(fts=None, filters={"sex": "MALE", "age": "< 10"})
+
+        query = DiscoveryQuery(filters={})
+        self.assertListEqual(query.queried_filter_fields(), [])
+        self.assertTrue(query.is_empty())
+
+        query = DiscoveryQuery(fts="", filters={})
+        self.assertListEqual(query.queried_filter_fields(), [])
+        self.assertTrue(query.is_empty())
+
+    def test_queried_filter_fields(self):
+        query = DiscoveryQuery(filters={"sex": "MALE", "age": "< 10"})
         self.assertListEqual(query.queried_filter_fields(), ["sex", "age"])
         self.assertFalse(query.is_empty())
 
@@ -42,7 +52,7 @@ class TestDiscoveryQueryModel(SimpleTestCase):
         dr.GET["sex"] = "MALE"
         dr.GET["age"] = "< 10"
         filter_q = DiscoveryQuery.from_drf_request(DrfRequest(dr))
-        self.assertIsNone(filter_q.fts)
+        self.assertEqual(filter_q.fts, "")  # no FTS
         self.assertDictEqual(filter_q.filters, {"sex": "MALE", "age": "< 10"})
         self.assertFalse(filter_q.is_empty())
 
@@ -61,7 +71,7 @@ class TestDiscoveryQueryModel(SimpleTestCase):
 
     def test_construction_from_post_request(self):
         filter_q = DiscoveryQuery.from_drf_request(self._mock_json_post({"sex": "MALE", "age": "< 10"}))
-        self.assertIsNone(filter_q.fts)
+        self.assertEqual(filter_q.fts, "")  # no FTS
         self.assertEqual(filter_q.fts_type, "plain")  # default
         self.assertDictEqual(filter_q.filters, {"sex": "MALE", "age": "< 10"})
 
@@ -84,3 +94,7 @@ class TestDiscoveryQueryModel(SimpleTestCase):
             dr.GET["_fts"] = "text"
             DiscoveryQuery.from_drf_request(DrfRequest(dr))
             # Not implemented - method is not GET|POST
+
+    def test_construction_blank_fts_from_request(self):
+        q = DiscoveryQuery.from_drf_request(self._mock_json_post({}))
+        self.assertEqual(q.fts, "")

--- a/chord_metadata_service/discovery/tests/test_scope.py
+++ b/chord_metadata_service/discovery/tests/test_scope.py
@@ -24,6 +24,15 @@ class DiscoveryScopeBuildingTestCase(ProjectTestCase):
         self.assertEqual(self.project_dataset_scope.project_id, str(self.project.identifier))
         self.assertEqual(self.project_dataset_scope.dataset_id, str(self.dataset.identifier))
 
+    def test_scope_eq(self):
+        self.assertEqual(self.project_scope, ValidatedDiscoveryScope(self.project, None))
+        self.assertEqual(INSTANCE_SCOPE, ValidatedDiscoveryScope(None, None))
+        self.assertEqual(ValidatedDiscoveryScope(None, None), ValidatedDiscoveryScope(None, None))
+        self.assertEqual(self.project_dataset_scope, ValidatedDiscoveryScope(self.project, self.dataset))
+        self.assertNotEqual(INSTANCE_SCOPE, self.project_scope)
+        self.assertNotEqual(INSTANCE_SCOPE, self.project_dataset_scope)
+        self.assertNotEqual(self.project_scope, ValidatedDiscoveryScope(self.project_2, None))
+
     def test_scope_hash(self):
         self.assertEqual(hash(self.instance_scope), hash("|"))
         self.assertEqual(hash(self.project_scope), hash(f"{self.project.identifier}|"))


### PR DESCRIPTION
* renames QueryQuerysetsCache to QueryHelper
* encapsulates some entity count methods in QueryHelper
* censors nested entity/field results if parent entity is censored (e.g., biosamples are *now* always censored if individuals are censored)