### PR TITLE
fix(cleanup): add missing cleanup for variant interpretations

### DIFF
--- a/chord_metadata_service/cleanup/run_all.py
+++ b/chord_metadata_service/cleanup/run_all.py
@@ -18,7 +18,7 @@ async def run_all_cleanup(logger: BoundLogger) -> int:
     n_removed: int = 0
 
     # Phenopacket artifacts - metadata objects + biosamples + phenotypic features + interpretations + diagnoses
-    #  + genomic/variant interpretations (order matters!)
+    #  + genomic/variant interpretations + variation descriptors (order matters!)
     n_removed += await pc.clean_meta_data(logger)
     n_removed += await pc.clean_biosamples(logger)
     n_removed += await pc.clean_phenotypic_features(logger)
@@ -26,6 +26,7 @@ async def run_all_cleanup(logger: BoundLogger) -> int:
     n_removed += await pc.clean_diagnoses(logger)
     n_removed += await pc.clean_genomic_interpretations(logger)
     n_removed += await pc.clean_variant_interpretations(logger)
+    n_removed += await pc.clean_variation_descriptors(logger)
 
     # Geographic locations - referenced by biosamples (we first need to have cleaned biosamples above)
     n_removed += await gc.clean_geolocations(logger)

--- a/chord_metadata_service/cleanup/run_all.py
+++ b/chord_metadata_service/cleanup/run_all.py
@@ -17,13 +17,15 @@ async def run_all_cleanup(logger: BoundLogger) -> int:
 
     n_removed: int = 0
 
-    # Phenopacket artifacts - metadata objects + biosamples + phenotypic features + procedures (order matters!)
+    # Phenopacket artifacts - metadata objects + biosamples + phenotypic features + interpretations + diagnoses
+    #  + genomic/variant interpretations (order matters!)
     n_removed += await pc.clean_meta_data(logger)
     n_removed += await pc.clean_biosamples(logger)
     n_removed += await pc.clean_phenotypic_features(logger)
     n_removed += await pc.clean_interpretations(logger)
     n_removed += await pc.clean_diagnoses(logger)
     n_removed += await pc.clean_genomic_interpretations(logger)
+    n_removed += await pc.clean_variant_interpretations(logger)
 
     # Geographic locations - referenced by biosamples (we first need to have cleaned biosamples above)
     n_removed += await gc.clean_geolocations(logger)

--- a/chord_metadata_service/cleanup/tests/test_cleanup.py
+++ b/chord_metadata_service/cleanup/tests/test_cleanup.py
@@ -142,6 +142,7 @@ class CleanUpIndividualsAndPhenopacketsTestCase(AuthzAPITestCase):
         self.assertEqual(await pc.clean_diagnoses(logger), 0)
         self.assertEqual(await pc.clean_genomic_interpretations(logger), 0)
         self.assertEqual(await pc.clean_variant_interpretations(logger), 0)
+        self.assertEqual(await pc.clean_variation_descriptors(logger), 0)
         self.assertEqual(await clean_individuals(logger), 0)
         self.assertEqual(await clean_resources(logger), 0)
 
@@ -181,7 +182,8 @@ class CleanUpIndividualsAndPhenopacketsTestCase(AuthzAPITestCase):
         # 1 interpretation +
         # 1 diagnosis +
         # 1 genomic interpretation +
-        # 1 variant interpretation
+        # 1 variant interpretation +
+        # 1 variation descriptor
 
         # Experiment artifacts
         # 0 experiment results +
@@ -192,8 +194,8 @@ class CleanUpIndividualsAndPhenopacketsTestCase(AuthzAPITestCase):
 
         # Resources
         # 1 resource +
-        # = 10 objects total
-        self.assertEqual(await run_all_cleanup(logger), 10)
+        # = 11 objects total
+        self.assertEqual(await run_all_cleanup(logger), 11)
 
         # Should have been removed via cascade with v2.17.0 database changes
         with self.assertRaises(PhenotypicFeature.DoesNotExist):

--- a/chord_metadata_service/cleanup/tests/test_cleanup.py
+++ b/chord_metadata_service/cleanup/tests/test_cleanup.py
@@ -123,6 +123,7 @@ class CleanUpIndividualsAndPhenopacketsTestCase(AuthzAPITestCase):
         self.assertEqual(await pc.clean_interpretations(logger), 0)
         self.assertEqual(await pc.clean_diagnoses(logger), 0)
         self.assertEqual(await pc.clean_genomic_interpretations(logger), 0)
+        self.assertEqual(await pc.clean_variant_interpretations(logger), 0)
         self.assertEqual(await clean_individuals(logger), 0)
         self.assertEqual(await clean_resources(logger), 0)
 
@@ -140,6 +141,7 @@ class CleanUpIndividualsAndPhenopacketsTestCase(AuthzAPITestCase):
         self.assertEqual(await pc.clean_interpretations(logger), 0)
         self.assertEqual(await pc.clean_diagnoses(logger), 0)
         self.assertEqual(await pc.clean_genomic_interpretations(logger), 0)
+        self.assertEqual(await pc.clean_variant_interpretations(logger), 0)
         self.assertEqual(await clean_individuals(logger), 0)
         self.assertEqual(await clean_resources(logger), 0)
 
@@ -177,8 +179,9 @@ class CleanUpIndividualsAndPhenopacketsTestCase(AuthzAPITestCase):
         # 0 linked phenotypic feature (removed via cascade with v2.17.0 database changes) +
         # 1 unlinked phenotypic feature (pretend left-over from pre v2.17.0 or created manually) +
         # 1 interpretation +
-        # 1 diagnosis
-        # 1 genomic interpretation
+        # 1 diagnosis +
+        # 1 genomic interpretation +
+        # 1 variant interpretation
 
         # Experiment artifacts
         # 0 experiment results +
@@ -189,8 +192,8 @@ class CleanUpIndividualsAndPhenopacketsTestCase(AuthzAPITestCase):
 
         # Resources
         # 1 resource +
-        # = 9 objects total
-        self.assertEqual(await run_all_cleanup(logger), 9)
+        # = 10 objects total
+        self.assertEqual(await run_all_cleanup(logger), 10)
 
         # Should have been removed via cascade with v2.17.0 database changes
         with self.assertRaises(PhenotypicFeature.DoesNotExist):

--- a/chord_metadata_service/cleanup/tests/test_cleanup.py
+++ b/chord_metadata_service/cleanup/tests/test_cleanup.py
@@ -124,6 +124,7 @@ class CleanUpIndividualsAndPhenopacketsTestCase(AuthzAPITestCase):
         self.assertEqual(await pc.clean_diagnoses(logger), 0)
         self.assertEqual(await pc.clean_genomic_interpretations(logger), 0)
         self.assertEqual(await pc.clean_variant_interpretations(logger), 0)
+        self.assertEqual(await pc.clean_variation_descriptors(logger), 0)
         self.assertEqual(await clean_individuals(logger), 0)
         self.assertEqual(await clean_resources(logger), 0)
 

--- a/chord_metadata_service/phenopackets/cleanup.py
+++ b/chord_metadata_service/phenopackets/cleanup.py
@@ -14,6 +14,7 @@ __all__ = [
     "clean_diagnoses",
     "clean_genomic_interpretations",
     "clean_variant_interpretations",
+    "clean_variation_descriptors",
 ]
 
 
@@ -91,4 +92,11 @@ async def clean_variant_interpretations(logger: BoundLogger) -> int:
     vis_referenced = await build_id_set_from_model(pm.GenomicInterpretation, "variant_interpretation")
     return await remove_not_referenced(
         pm.VariantInterpretation, vis_referenced, "variant interpretations", logger
+    )
+
+
+async def clean_variation_descriptors(logger: BoundLogger) -> int:
+    vds_referenced = await build_id_set_from_model(pm.VariantInterpretation, "variation_descriptor")
+    return await remove_not_referenced(
+        pm.VariationDescriptor, vds_referenced, "variation descriptors", logger
     )

--- a/chord_metadata_service/phenopackets/cleanup.py
+++ b/chord_metadata_service/phenopackets/cleanup.py
@@ -10,6 +10,10 @@ __all__ = [
     "clean_meta_data",
     "clean_biosamples",
     "clean_phenotypic_features",
+    "clean_interpretations",
+    "clean_diagnoses",
+    "clean_genomic_interpretations",
+    "clean_variant_interpretations",
 ]
 
 
@@ -80,4 +84,11 @@ async def clean_genomic_interpretations(logger: BoundLogger) -> int:
     gi_referenced = await build_id_set_from_model(pm.Diagnosis, "genomic_interpretations__id")
     return await remove_not_referenced(
         pm.GenomicInterpretation, gi_referenced, "genomic interpretations", logger
+    )
+
+
+async def clean_variant_interpretations(logger: BoundLogger) -> int:
+    vis_referenced = await build_id_set_from_model(pm.GenomicInterpretation, "variant_interpretation")
+    return await remove_not_referenced(
+        pm.VariantInterpretation, vis_referenced, "variant interpretations", logger
     )


### PR DESCRIPTION
variant interpretations weren't getting cleaned up, which was causing ingestion errors if it changed subtly.