### PR TITLE
fix(restapi): keep falsey numeric fields in GenericSerializer

### DIFF
--- a/chord_metadata_service/restapi/serializers.py
+++ b/chord_metadata_service/restapi/serializers.py
@@ -1,5 +1,6 @@
 from collections import OrderedDict
 from rest_framework import serializers
+from typing import Sequence
 
 
 class GenericSerializer(serializers.ModelSerializer):
@@ -7,7 +8,7 @@ class GenericSerializer(serializers.ModelSerializer):
     always_include: tuple[str, ...] = ()
 
     def __init__(self, *args, **kwargs):
-        exclude_when_nested = kwargs.pop('exclude_when_nested', None)
+        exclude_when_nested: Sequence[str] | None = kwargs.pop("exclude_when_nested", None)
         super(GenericSerializer, self).__init__(*args, **kwargs)
 
         if exclude_when_nested:
@@ -17,8 +18,11 @@ class GenericSerializer(serializers.ModelSerializer):
     def to_representation(self, instance):
         """ Return only not empty fields """
         final_object = super().to_representation(instance)
-        # filter null values and create new dict
+        # filter null/falsey values and create new dict - but keep any integers/floats, even if 0
         final_object = OrderedDict(
-            list(filter(lambda x: x[1] is not None or x[0] in self.always_include, final_object.items()))
+            list(filter(
+                lambda x: x[1] or isinstance(x[1], int) or isinstance(x[1], float) or x[0] in self.always_include,
+                final_object.items()
+            ))
         )
         return final_object

--- a/chord_metadata_service/restapi/serializers.py
+++ b/chord_metadata_service/restapi/serializers.py
@@ -18,5 +18,7 @@ class GenericSerializer(serializers.ModelSerializer):
         """ Return only not empty fields """
         final_object = super().to_representation(instance)
         # filter null values and create new dict
-        final_object = OrderedDict(list(filter(lambda x: x[1] or x[0] in self.always_include, final_object.items())))
+        final_object = OrderedDict(
+            list(filter(lambda x: x[1] is not None or x[0] in self.always_include, final_object.items()))
+        )
         return final_object


### PR DESCRIPTION
was preventing survival time in days with 0/0.0 as a value from being serialized in vital status.