### PR TITLE
feat(phenopackets): serialize project ID in phenopacket JSON

### DIFF
--- a/chord_metadata_service/discovery/full_text_search.py
+++ b/chord_metadata_service/discovery/full_text_search.py
@@ -190,7 +190,7 @@ class BaseFTSModel(models.Model, FTSHelpersMixin):
     fts_extra = models.TextField(blank=True, null=False, default="")
 
     class Meta:
-        # Abstract prevents the creation of a BaseTimeStamp table
+        # Abstract prevents the creation of a BaseFTSModel table
         abstract = True
 
     def get_fts_extra(self) -> tuple:

--- a/chord_metadata_service/patients/api_views.py
+++ b/chord_metadata_service/patients/api_views.py
@@ -160,6 +160,8 @@ class IndividualViewSet(BentoAuthzScopedModelViewSet):
             Phenopacket.get_model_scoped_queryset(scope)
             .filter(subject=individual)
             .prefetch_related(*PHENOPACKET_PREFETCH)
+            .select_related(*PHENOPACKET_SELECT_REL)
+            .annotate(project=F("dataset__project_id"))
             .order_by("id")
         )
 

--- a/chord_metadata_service/phenopackets/api_views.py
+++ b/chord_metadata_service/phenopackets/api_views.py
@@ -1,5 +1,6 @@
 from asgiref.sync import async_to_sync
 from bento_lib.auth.permissions import P_QUERY_DATA
+from django.db.models import F
 from django_filters.rest_framework import DjangoFilterBackend
 from drf_spectacular.utils import extend_schema, inline_serializer
 from rest_framework import serializers, status
@@ -143,6 +144,7 @@ PHENOPACKET_PREFETCH = (
 )
 
 PHENOPACKET_SELECT_REL = (
+    "dataset",
     "subject",
     "meta_data",
 )
@@ -169,6 +171,7 @@ class PhenopacketViewSet(PhenopacketsModelViewSet):
             m.Phenopacket.get_model_scoped_queryset(await get_request_discovery_scope(self.request))
             .prefetch_related(*PHENOPACKET_PREFETCH)
             .select_related(*PHENOPACKET_SELECT_REL)
+            .annotate(project=F("dataset__project_id"))
             .order_by("id")
         )
 

--- a/chord_metadata_service/phenopackets/serializers.py
+++ b/chord_metadata_service/phenopackets/serializers.py
@@ -1,4 +1,5 @@
 from rest_framework import serializers
+from rest_framework.fields import CharField
 
 from chord_metadata_service.restapi.utils import computed_property
 from .models import (
@@ -224,6 +225,8 @@ class InterpretationSerializer(GenericSerializer):
 
 class SimplePhenopacketSerializer(GenericSerializer):
     # Note: this serializer is always nested
+
+    project = CharField(read_only=True)
 
     phenotypic_features = PhenotypicFeatureSerializer(read_only=True, many=True)
     interpretations = InterpretationSerializer(many=True, required=False)

--- a/chord_metadata_service/phenopackets/tests/test_api.py
+++ b/chord_metadata_service/phenopackets/tests/test_api.py
@@ -257,11 +257,11 @@ class GetPhenopacketsApiTest(AuthzAPITestCase):
         """
         Create two datasets and ingest 1 phenopacket into each.
         """
-        p = Project.objects.create(title="Project 1", description="")
+        self.p = Project.objects.create(title="Project 1", description="")
         self.d = Dataset.objects.create(title="dataset_1", description="Some dataset", data_use=VALID_DATA_USE_1,
-                                        project=p)
+                                        project=self.p)
         self.d2 = Dataset.objects.create(title="dataset_2", description="Some dataset", data_use=VALID_DATA_USE_1,
-                                         project=p)
+                                         project=self.p)
 
         WORKFLOW_INGEST_FUNCTION_MAP[WORKFLOW_PHENOPACKETS_JSON](
             restapi_c.VALID_PHENOPACKET_1, self.d.identifier, logger)
@@ -291,6 +291,8 @@ class GetPhenopacketsApiTest(AuthzAPITestCase):
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         response_data = response.json()
         self.assertEqual(len(response_data["results"]), 1)
+        self.assertEqual(response_data["results"][0]["project"], str(self.p.identifier))
+        self.assertEqual(response_data["results"][0]["dataset"], str(self.d.identifier))
 
     def test_get_phenopackets_with_valid_dataset_via_scope_no_access(self):
         """


### PR DESCRIPTION
this could help front ends/API consumers with navigation and grouping on initial fetch of a phenopacket in detail view, for example.