### PR TITLE
feat(chord): update resources with the same ID with new ingestions

### DIFF
--- a/chord_metadata_service/chord/ingest/experiments.py
+++ b/chord_metadata_service/chord/ingest/experiments.py
@@ -167,7 +167,7 @@ def ingest_experiments_workflow(json_data, dataset_id: str, lg: BoundLogger) -> 
     lg = lg.bind(project_id=str(dataset.project_id), dataset_id=dataset_id)
 
     for rs in json_data.get("resources", []):
-        dataset.additional_resources.add(ingest_resource(rs))
+        dataset.additional_resources.add(ingest_resource(rs, lg))
 
     exps = json_data.get("experiments", [])
 

--- a/chord_metadata_service/chord/ingest/phenopackets.py
+++ b/chord_metadata_service/chord/ingest/phenopackets.py
@@ -422,7 +422,7 @@ def ingest_phenopacket(
     biosamples_db = [get_or_create_biosample(bs, lg) for bs in biosamples]
 
     # Get or create all resources (ontologies, etc.) in the phenopacket
-    resources_db = [ingest_resource(rs) for rs in resources]
+    resources_db = [ingest_resource(rs, lg) for rs in resources]
 
     interpretations_db = [
         get_or_create_interpretation(interp, subject=subject_obj, biosamples=biosamples_db)

--- a/chord_metadata_service/chord/ingest/resources.py
+++ b/chord_metadata_service/chord/ingest/resources.py
@@ -48,7 +48,6 @@ def ingest_resource(resource: dict, logger: BoundLogger) -> rm.Resource:
         version=version,
         iri_prefix=resource["iri_prefix"],
         extra_properties=resource.get("extra_properties", {}),
-        # TODO extra_properties
     )
 
     return rs_obj

--- a/chord_metadata_service/chord/ingest/resources.py
+++ b/chord_metadata_service/chord/ingest/resources.py
@@ -1,12 +1,44 @@
+import json
 from chord_metadata_service.resources import models as rm, utils as ru
+from structlog.stdlib import BoundLogger
 
 __all__ = ["ingest_resource"]
 
 
-def ingest_resource(resource: dict) -> rm.Resource:
+def ingest_resource(resource: dict, logger: BoundLogger) -> rm.Resource:
     namespace_prefix = resource["namespace_prefix"].strip()
     version = resource.get("version", "").strip()
     assigned_resource_id = ru.make_resource_id(namespace_prefix, version)
+
+    try:
+        # if we already have a resource with this assigned ID, update it with the latest definition during this
+        # ingestion run (allowing us to fix IRI prefixes, for example):
+
+        existing_rs = rm.Resource.objects.get(
+            id=assigned_resource_id, namespace_prefix=namespace_prefix, version=version
+        )
+
+        if (
+            existing_rs.name != resource["name"]
+            or existing_rs.url != resource["url"]
+            or existing_rs.iri_prefix != resource["iri_prefix"]
+            or (
+                json.dumps(resource.get("extra_properties", {}), sort_keys=True)
+                != json.dumps(existing_rs.extra_properties, sort_keys=True)
+            )
+        ):
+            logger.warning("updating existing resource", resource=resource)
+
+            existing_rs.name = resource["name"]
+            existing_rs.url = resource["url"]
+            existing_rs.iri_prefix = resource["iri_prefix"]
+            existing_rs.extra_properties = resource.get("extra_properties", existing_rs.extra_properties)
+            existing_rs.save()
+
+        return existing_rs
+
+    except rm.Resource.DoesNotExist:
+        pass
 
     rs_obj, _ = rm.Resource.objects.get_or_create(
         id=assigned_resource_id,
@@ -15,7 +47,7 @@ def ingest_resource(resource: dict) -> rm.Resource:
         url=resource["url"],
         version=version,
         iri_prefix=resource["iri_prefix"],
-        extra_properties=resource.get("extra_properties", {})
+        extra_properties=resource.get("extra_properties", {}),
         # TODO extra_properties
     )
 

--- a/chord_metadata_service/chord/tests/test_ingest_resources.py
+++ b/chord_metadata_service/chord/tests/test_ingest_resources.py
@@ -1,0 +1,58 @@
+from bento_lib.ontologies.common_resources import NCBI_TAXON_2025_12_03
+from structlog.stdlib import get_logger
+from .helpers import ProjectTestCase, ModelFieldsTestMixin
+from chord_metadata_service.chord.ingest.resources import ingest_resource
+
+logger = get_logger("test")
+
+NCBITAXON_RESOURCE = {
+    # id field is ignored
+    "name": "NCBI Taxonomy OBO Edition",
+    "url": "http://purl.obolibrary.org/obo/ncbitaxon.owl",
+    "version": "2018-07-27",
+    "namespace_prefix": "NCBITaxon",
+    "iri_prefix": "http://purl.obolibrary.org/obo/NCBITaxon_"
+}
+
+
+class IngestResourcesTest(ProjectTestCase, ModelFieldsTestMixin):
+
+    def test_ingest_new_resource(self):
+        res = ingest_resource(NCBITAXON_RESOURCE, logger)
+        res.refresh_from_db()
+
+        self.assertEqual(res.id, "NCBITaxon:2018-07-27")
+        self.assertEqual(res.name, "NCBI Taxonomy OBO Edition")
+        self.assertEqual(res.url, "http://purl.obolibrary.org/obo/ncbitaxon.owl")
+        self.assertEqual(res.version, "2018-07-27")
+        self.assertEqual(res.namespace_prefix, "NCBITaxon")
+        self.assertEqual(res.iri_prefix, "http://purl.obolibrary.org/obo/NCBITaxon_")
+
+    def test_ingest_new_resource_from_bento_lib(self):
+        res = ingest_resource(NCBI_TAXON_2025_12_03.model_dump(mode="json"), logger)
+        res.refresh_from_db()
+
+        self.assertEqual(res.id, "NCBITaxon:2025-12-03")
+        self.assertEqual(res.name, NCBI_TAXON_2025_12_03.name)
+        self.assertEqual(res.url, str(NCBI_TAXON_2025_12_03.url))
+        self.assertEqual(res.version, NCBI_TAXON_2025_12_03.version)
+        self.assertEqual(res.namespace_prefix, NCBI_TAXON_2025_12_03.namespace_prefix)
+        self.assertEqual(res.iri_prefix, str(NCBI_TAXON_2025_12_03.iri_prefix))
+
+    def test_ingest_existing_resource_as_is(self):
+        res1 = ingest_resource(NCBI_TAXON_2025_12_03.model_dump(mode="json"), logger)
+        res2 = ingest_resource(NCBI_TAXON_2025_12_03.model_dump(mode="json"), logger)
+        self.assertEqual(res1, res2)
+
+    def test_ingest_updated_resource(self):
+        res1 = ingest_resource(NCBITAXON_RESOURCE, logger)
+
+        res2 = ingest_resource({
+            **NCBITAXON_RESOURCE,
+            "url": f"https://purl.obolibrary.org/obo/ncbitaxon/{NCBITAXON_RESOURCE['version']}/ncbitaxon.owl",
+        }, logger)
+
+        self.assertEqual(res1, res2)
+        self.assertEqual(res1.url, "http://purl.obolibrary.org/obo/ncbitaxon.owl")
+        res1.refresh_from_db()
+        self.assertEqual(res1.url, "https://purl.obolibrary.org/obo/ncbitaxon/2018-07-27/ncbitaxon.owl")


### PR DESCRIPTION
This doesn't deal with mismatched versions of resources, but it does let us change the URL of resources with the same ID.