### PR TITLE
fix(discovery): handle custom decimal bins in discovery number field

### DIFF
--- a/chord_metadata_service/discovery/fields.py
+++ b/chord_metadata_service/discovery/fields.py
@@ -427,10 +427,11 @@ async def filter_queryset_field_value(
             condition = get_condition_for_non_jsonb_field(field, (("iexact", value),), subquery)
 
     elif field_props.datatype == "number":
-        # values are of the form "[50, 150)", "< 50" or "≥ 800"
+        # values are of the form "[50, 150)", "< 50" or "≥ 800".
+        # important: custom bins can have decimals in them!
 
         if value.startswith("["):
-            [start, end] = [int(v) for v in value.lstrip("[").rstrip(")").split(", ")]
+            [start, end] = [f_utils.str_to_numeric(v) for v in value.lstrip("[").rstrip(")").split(", ")]
             if json_range_condition := f_utils.get_json_range_condition(queryset_entity, field_props, start, end):
                 # JSONField array range stats must use 'jsonb_path_exists' conditions
                 condition = json_range_condition
@@ -438,20 +439,21 @@ async def filter_queryset_field_value(
                 condition = get_condition_for_non_jsonb_field(field, (("gte", start), ("lt", end)), subquery)
         else:
             [sym, val] = value.split(" ")
+            val_numeric = f_utils.str_to_numeric(val)
             if sym == "≥":
                 if json_range_condition := f_utils.get_json_range_condition(
-                    queryset_entity, field_props, min=int(val)
+                    queryset_entity, field_props, min_value=val_numeric
                 ):
                     condition = json_range_condition
                 else:
-                    condition = get_condition_for_non_jsonb_field(field, (("gte", int(val)),), subquery)
+                    condition = get_condition_for_non_jsonb_field(field, (("gte", val_numeric),), subquery)
             elif sym == "<":
                 if json_range_condition := f_utils.get_json_range_condition(
-                    queryset_entity, field_props, max=int(val)
+                    queryset_entity, field_props, max_value=val_numeric
                 ):
                     condition = json_range_condition
                 else:
-                    condition = get_condition_for_non_jsonb_field(field, (("lt", int(val)),), subquery)
+                    condition = get_condition_for_non_jsonb_field(field, (("lt", val_numeric),), subquery)
             else:
                 raise NotImplementedError()
     elif field_props.datatype == "date":

--- a/chord_metadata_service/discovery/fields_utils.py
+++ b/chord_metadata_service/discovery/fields_utils.py
@@ -15,6 +15,7 @@ __all__ = [
     "monthly_generator",
     "get_nested_json_condition",
     "get_json_range_condition",
+    "str_to_numeric",
 ]
 
 MAPPING_SEPARATOR = "/"
@@ -178,7 +179,10 @@ def get_nested_json_condition(path: str, value: Any) -> dict[str, Any]:
 
 
 def get_json_range_condition(
-    filtering_entity: DiscoveryEntity, field_props: AnyFieldDefinition, min: int = None, max: int = None
+    filtering_entity: DiscoveryEntity,
+    field_props: AnyFieldDefinition,
+    min_value: int | float | None = None,
+    max_value: int | float | None = None,
 ) -> Q:
     """
     Takes field props for a 'number' data type contained in a JSONField array,
@@ -203,21 +207,25 @@ def get_json_range_condition(
         field = get_field_django_mapping(filtering_entity, field_props)
         group_by_json_path = mapping_to_json_path(group_by)
         value_json_path = mapping_to_json_path(value_mapping)
-        if min is not None:
+        if min_value is not None:
             min_condition = Q(JSONBPathFilter(
                 # Points to the JSONField
                 F(field),
                 # JSON path expression with GTE and group_by_value condition
-                Value(f'$[*] ? (@.{value_json_path} >= {min} && @.{group_by_json_path} == "{group_by_value}")')
+                Value(f'$[*] ? (@.{value_json_path} >= {min_value} && @.{group_by_json_path} == "{group_by_value}")')
             ))
             range_condition.add(min_condition, conn_type=Q.AND)
-        if max is not None:
+        if max_value is not None:
             max_condition = Q(JSONBPathFilter(
                 # Points to the JSONField
                 F(field),
                 # JSON path expression with LT and group_by_value condition
-                Value(f'$[*] ? (@.{value_json_path} < {max} && @.{group_by_json_path} == "{group_by_value}")')
+                Value(f'$[*] ? (@.{value_json_path} < {max_value} && @.{group_by_json_path} == "{group_by_value}")')
             ))
             range_condition.add(max_condition, Q.AND)
 
     return range_condition
+
+
+def str_to_numeric(value: str) -> int | float:
+    return float(value) if "." in value else int(value)

--- a/chord_metadata_service/discovery/tests/constants.py
+++ b/chord_metadata_service/discovery/tests/constants.py
@@ -151,7 +151,7 @@ DISCOVERY_CONFIG_EXTRA_PROPERTIES_DICT["fields"].update({
         "description": "This acts as a placeholder for numeric values",
         "datatype": "number",
         "config": {
-            "bins": [200, 300, 500, 1000, 1500, 2000],
+            "bins": [55.5, 200, 300, 500, 1000, 1255.5, 1500, 2000],
             "minimum": 0,
             "units": "mg/L"
         }

--- a/chord_metadata_service/discovery/tests/test_fields_utils.py
+++ b/chord_metadata_service/discovery/tests/test_fields_utils.py
@@ -9,6 +9,7 @@ from ..fields_utils import (
     get_json_range_condition,
     labelled_range_generator,
     get_nested_json_condition,
+    str_to_numeric,
 )
 
 
@@ -54,7 +55,7 @@ class TestLabelledRangeGeneratorCustomBins(TestCase):
             "title": "Test",
             "description": "A test field",
             "config": {
-                "bins": [200, 300, 500, 1000, 1500, 2000],
+                "bins": [5.5, 200, 300, 500, 1000, 1500, 2000],
                 "minimum": 0,
                 "units": "mg/L"
             }
@@ -62,16 +63,29 @@ class TestLabelledRangeGeneratorCustomBins(TestCase):
 
     def test_custom_bins_config(self):
         rg = list(labelled_range_generator(self.fp))
-        self.assertEqual(rg[0], (0, 200, "< 200"))
+        self.assertEqual(rg[0], (0, 5.5, "< 5.5"))
         self.assertEqual(rg[-1], (2000, None, "≥ 2000"))
-        self.assertEqual(rg[1], (200, 300, "[200, 300)"))
+        self.assertEqual(rg[1], (5.5, 200, "[5.5, 200)"))
 
     def test_custom_bins_config_no_open_ended(self):
-        self.fp.config.minimum = 200
+        self.fp.config.minimum = 0
+        self.fp.config.bins.insert(0, 0)
         self.fp.config.maximum = 2000
         rg = list(labelled_range_generator(self.fp))
         self.assertIn("[", rg[0][2])
         self.assertIn("[", rg[-1][2])
+
+    def test_str_to_numeric(self):
+        subtests = [
+            ("5.5", 5.5),
+            ("5.", 5.0),
+            ("5", 5),
+            (".5", 0.5),
+        ]
+
+        for params in subtests:
+            with self.subTest(params=params):
+                self.assertEqual(str_to_numeric(params[0]), params[1])
 
 
 class TestJsonFieldUtils(TestCase):
@@ -123,15 +137,17 @@ class TestJsonFieldUtils(TestCase):
         field_props = DISCOVERY_CONFIG_TEST.fields["measurement_tumor_length"]
 
         # GTE 0 an LT 20
-        json_range_condition_0_20 = get_json_range_condition("phenopacket", field_props, min=0, max=20)
+        json_range_condition_0_20 = get_json_range_condition(
+            "phenopacket", field_props, min_value=0, max_value=20
+        )
         self.assertTrue(len(json_range_condition_0_20), 2)  # expect 2 conditions (GTE and LT)
 
         # GTE 0
-        json_range_condition_gte_0 = get_json_range_condition("phenopacket", field_props, min=0)
+        json_range_condition_gte_0 = get_json_range_condition("phenopacket", field_props, min_value=0)
         self.assertTrue(len(json_range_condition_gte_0), 1)
 
         # LT 20
-        json_range_condition_lt_20 = get_json_range_condition("phenopacket", field_props, max=20)
+        json_range_condition_lt_20 = get_json_range_condition("phenopacket", field_props, max_value=20)
         self.assertTrue(len(json_range_condition_lt_20), 1)
 
         # Combined Q object
@@ -139,6 +155,14 @@ class TestJsonFieldUtils(TestCase):
         combined.add(json_range_condition_gte_0, Q.AND)
         combined.add(json_range_condition_lt_20, Q.AND)
         self.assertEqual(json_range_condition_0_20, combined)
+
+        # GTE 0.5
+        json_range_condition_gte_0_5 = get_json_range_condition("phenopacket", field_props, min_value=0.5)
+        self.assertTrue(len(json_range_condition_gte_0_5), 1)
+
+        # LT 20.5
+        json_range_condition_lt_20_5 = get_json_range_condition("phenopacket", field_props, max_value=20.5)
+        self.assertTrue(len(json_range_condition_lt_20_5), 1)
 
     def test_jsonb_path_query_empty(self):
         assay_ids_query = get_jsonb_path_query("measurements", "assay/id")

--- a/chord_metadata_service/patients/tests/test_api.py
+++ b/chord_metadata_service/patients/tests/test_api.py
@@ -747,33 +747,43 @@ class DiscoveryFilteringIndividualsTest(AuthzAPITestCase, ProjectTestCase):
 
     @override_settings(CONFIG_PUBLIC=DISCOVERY_CONFIG_EXTRA_PROPERTIES)
     def test_discovery_filtering_extra_properties_range_string_1(self):
-        # sex string search and extra_properties range search
-        response = self.dt_authz_counts_get(
-            '/api/discovery?sex=female&lab_test_result_value=< 200'
-        )
-        self.assertEqual(response.status_code, status.HTTP_200_OK)
-        response_obj = response.json()
-        range_parameters = {
-            "sex__iexact": "female",
-            "extra_properties__lab_test_result_value__gte": 0,
-            "extra_properties__lab_test_result_value__lt": 200
-        }
-        db_count = Individual.objects.filter(**range_parameters).count()
-        self.assertIn(self.response_threshold_check(response_obj), [db_count, dres.INSUFFICIENT_DATA_AVAILABLE])
-        self._test_individual_counts(response_obj, db_count)
+        # test combined sex string search + extra_properties range search,
+        # with variety of ranges for lab_test_result_value including some decimal ones (which used to not work!)
+
+        subtests = [
+            ("< 55.5", 0, 55.5),
+            ("[200, 300)", 200, 300),
+            ("[1000, 1255.5)", 1000, 1255.5),
+            ("[1255.5, 1500)", 1000, 1255.5),
+        ]
+
+        for params in subtests:
+            with self.subTest(params=params):
+                # sex string search and extra_properties range search
+                response = self.dt_authz_counts_get(f"/api/discovery?sex=female&lab_test_result_value={params[0]}")
+                self.assertEqual(response.status_code, status.HTTP_200_OK)
+                response_obj = response.json()
+                range_parameters = {
+                    "sex__iexact": "female",
+                    "extra_properties__lab_test_result_value__gte": params[1],
+                    "extra_properties__lab_test_result_value__lt": params[2],
+                }
+                db_count = Individual.objects.filter(**range_parameters).count()
+                self.assertIn(self.response_threshold_check(response_obj), [db_count, dres.INSUFFICIENT_DATA_AVAILABLE])
+                self._test_individual_counts(response_obj, db_count)
 
     @override_settings(CONFIG_PUBLIC=DISCOVERY_CONFIG_EXTRA_PROPERTIES)
     def test_discovery_filtering_extra_properties_range_string_2(self):
         # extra_properties range search and extra_properties string search (single value)
 
         response = self.dt_authz_counts_get(
-            '/api/discovery?lab_test_result_value=< 200&covidstatus=positive'
+            '/api/discovery?lab_test_result_value=< 55.5&covidstatus=positive'
         )
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         response_obj = response.json()
         range_parameters = {
             "extra_properties__lab_test_result_value__gte": 0,
-            "extra_properties__lab_test_result_value__lt": 200,
+            "extra_properties__lab_test_result_value__lt": 55.5,
             "extra_properties__covidstatus__iexact": "positive",
         }
 
@@ -786,13 +796,13 @@ class DiscoveryFilteringIndividualsTest(AuthzAPITestCase, ProjectTestCase):
     def test_discovery_filtering_extra_properties_multiple_ranges_1(self):
         # extra_properties range search (both min and max range, multiple values)
         response = self.dt_authz_counts_get(
-            '/api/discovery?lab_test_result_value=< 200&baseline_creatinine=[100, 150)'
+            '/api/discovery?lab_test_result_value=< 55.5&baseline_creatinine=[100, 150)'
         )
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         response_obj = response.json()
         range_parameters = {
             "extra_properties__lab_test_result_value__gte": 0,
-            "extra_properties__lab_test_result_value__lt": 200,
+            "extra_properties__lab_test_result_value__lt": 55.5,
             "extra_properties__baseline_creatinine__gte": 100,
             "extra_properties__baseline_creatinine__lt": 150,
         }
@@ -821,14 +831,14 @@ class DiscoveryFilteringIndividualsTest(AuthzAPITestCase, ProjectTestCase):
         # extra_properties date range search (both after and before, single value) and other number range search
         # Testing with a date of consent from 2 years ago
         response = self.dt_authz_counts_get(
-            '/api/discovery?date_of_consent=Mar 2021&lab_test_result_value=< 200'
+            '/api/discovery?date_of_consent=Mar 2021&lab_test_result_value=< 55.5'
         )
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         response_obj = response.json()
         range_parameters = {
             "extra_properties__date_of_consent__startswith": "2021-03",
             "extra_properties__lab_test_result_value__gte": 0,
-            "extra_properties__lab_test_result_value__lt": 200,
+            "extra_properties__lab_test_result_value__lt": 55.5,
         }
         db_count = Individual.objects.filter(**range_parameters).count()
         self.assertIn(self.response_threshold_check(response_obj), [db_count, dres.INSUFFICIENT_DATA_AVAILABLE])


### PR DESCRIPTION
auto-generated decimal bins is a more complex issue, not tackling that here.

https://redmine.c3g-app.sd4h.ca/issues/2723