### PR TITLE
fix spelling of scChIC-seq in experiment type

### DIFF
--- a/chord_metadata_service/experiments/schemas.py
+++ b/chord_metadata_service/experiments/schemas.py
@@ -170,7 +170,7 @@ EXPERIMENT_SCHEMA = tag_ids_and_describe({
                 # Epigenomics
                 "DNA Methylation", "WGBS", "ChIP-Seq", "CUT&RUN", "CUT&Tag", "ATAC-Seq", "scATAC-Seq",
                 # 3D Genomics
-                "Hi-C", "scHiC-Seq",
+                "Hi-C", "scChIC-seq",
                 # Multi-Omics
                 "Multiome",
                 # Other omics


### PR DESCRIPTION
Spelling fix for scChIC-seq, see, eg, [here](https://pmc.ncbi.nlm.nih.gov/articles/PMC7187538/) for a reference. 