### PR TITLE
spelling fix for single cell Hi-C

### DIFF
--- a/chord_metadata_service/experiments/schemas.py
+++ b/chord_metadata_service/experiments/schemas.py
@@ -170,7 +170,7 @@ EXPERIMENT_SCHEMA = tag_ids_and_describe({
                 # Epigenomics
                 "DNA Methylation", "WGBS", "ChIP-Seq", "CUT&RUN", "CUT&Tag", "ATAC-Seq", "scATAC-Seq",
                 # 3D Genomics
-                "Hi-C", "scHiC-Seq",
+                "Hi-C", "scHi-C",
                 # Multi-Omics
                 "Multiome",
                 # Other omics


### PR DESCRIPTION
single cell Hi-C should be "scHi-C", see e.g. [here](https://advanced.onlinelibrary.wiley.com/doi/10.1002/advs.202412232) for a reference. 