### PR TITLE
fix: populate chord_datasetv2 before adding FK constraints

### DIFF
--- a/chord_metadata_service/chord/management/commands/fix_dataset_v2_migration_history.py
+++ b/chord_metadata_service/chord/management/commands/fix_dataset_v2_migration_history.py
@@ -77,20 +77,20 @@ class Command(BaseCommand):
                     "DELETE FROM django_migrations WHERE app=%s AND name=%s",
                     list(_MIGRATION_0017),
                 )
-                self.stdout.write(f"  Removed experiments.0017 from django_migrations")
+                self.stdout.write("  Removed experiments.0017 from django_migrations")
 
             if applied_0019:
                 cursor.execute(
                     "DELETE FROM django_migrations WHERE app=%s AND name=%s",
                     list(_MIGRATION_0019),
                 )
-                self.stdout.write(f"  Removed phenopackets.0019 from django_migrations")
+                self.stdout.write("  Removed phenopackets.0019 from django_migrations")
 
             cursor.execute(
                 "INSERT INTO django_migrations (app, name, applied) VALUES (%s, %s, %s)",
                 [_MIGRATION_0013[0], _MIGRATION_0013[1], timezone.now()],
             )
-            self.stdout.write(f"  Inserted chord.0013 into django_migrations")
+            self.stdout.write("  Inserted chord.0013 into django_migrations")
 
         if applied_0017:
             call_command("migrate", "experiments", "0017_experiment_dataset_v2", fake=True, verbosity=0)

--- a/chord_metadata_service/chord/management/commands/fix_dataset_v2_migration_history.py
+++ b/chord_metadata_service/chord/management/commands/fix_dataset_v2_migration_history.py
@@ -1,0 +1,103 @@
+"""
+Management command to fix InconsistentMigrationHistory on systems where
+experiments.0017 and phenopackets.0019 were applied before chord.0013 existed.
+
+Run this before `python manage.py migrate` on affected systems.
+"""
+
+from django.core.management import call_command
+from django.core.management.base import BaseCommand
+from django.db import connection
+from django.utils import timezone
+
+
+_MIGRATION_0013 = ("chord", "0013_migrate_datasets_to_v2")
+_MIGRATION_0017 = ("experiments", "0017_experiment_dataset_v2")
+_MIGRATION_0019 = ("phenopackets", "0019_phenopacket_dataset_v2")
+
+
+def _is_applied(cursor, app, name):
+    cursor.execute(
+        "SELECT 1 FROM django_migrations WHERE app=%s AND name=%s",
+        [app, name],
+    )
+    return cursor.fetchone() is not None
+
+
+class Command(BaseCommand):
+    help = (
+        "Fix InconsistentMigrationHistory caused by chord.0013 being added after "
+        "experiments.0017 and phenopackets.0019 were already applied manually."
+    )
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "--dry-run",
+            action="store_true",
+            default=False,
+            help="Print what would be done without making changes.",
+        )
+
+    def handle(self, *args, **options):
+        dry_run = options["dry_run"]
+
+        with connection.cursor() as cursor:
+            applied_0013 = _is_applied(cursor, *_MIGRATION_0013)
+            applied_0017 = _is_applied(cursor, *_MIGRATION_0017)
+            applied_0019 = _is_applied(cursor, *_MIGRATION_0019)
+
+        if applied_0013:
+            self.stdout.write("chord.0013 already in migration history. Nothing to do.")
+            return
+
+        if not applied_0017 and not applied_0019:
+            self.stdout.write("0017/0019 not applied yet. Run migrate normally.")
+            return
+
+        self.stdout.write(
+            "Detected: 0017/0019 applied, 0013 missing. Fixing migration history..."
+        )
+
+        if dry_run:
+            self.stdout.write(self.style.WARNING("DRY RUN — no changes will be made."))
+            if applied_0017:
+                self.stdout.write("  Would delete experiments.0017 from django_migrations")
+            if applied_0019:
+                self.stdout.write("  Would delete phenopackets.0019 from django_migrations")
+            self.stdout.write("  Would insert chord.0013 into django_migrations")
+            if applied_0017:
+                self.stdout.write("  Would fake-apply experiments.0017")
+            if applied_0019:
+                self.stdout.write("  Would fake-apply phenopackets.0019")
+            return
+
+        with connection.cursor() as cursor:
+            if applied_0017:
+                cursor.execute(
+                    "DELETE FROM django_migrations WHERE app=%s AND name=%s",
+                    list(_MIGRATION_0017),
+                )
+                self.stdout.write(f"  Removed experiments.0017 from django_migrations")
+
+            if applied_0019:
+                cursor.execute(
+                    "DELETE FROM django_migrations WHERE app=%s AND name=%s",
+                    list(_MIGRATION_0019),
+                )
+                self.stdout.write(f"  Removed phenopackets.0019 from django_migrations")
+
+            cursor.execute(
+                "INSERT INTO django_migrations (app, name, applied) VALUES (%s, %s, %s)",
+                [_MIGRATION_0013[0], _MIGRATION_0013[1], timezone.now()],
+            )
+            self.stdout.write(f"  Inserted chord.0013 into django_migrations")
+
+        if applied_0017:
+            call_command("migrate", "experiments", "0017_experiment_dataset_v2", fake=True, verbosity=0)
+            self.stdout.write("  Faked experiments.0017")
+
+        if applied_0019:
+            call_command("migrate", "phenopackets", "0019_phenopacket_dataset_v2", fake=True, verbosity=0)
+            self.stdout.write("  Faked phenopackets.0019")
+
+        self.stdout.write(self.style.SUCCESS("Done. Run `python manage.py migrate` now."))

--- a/chord_metadata_service/chord/migrations/0013_migrate_datasets_to_v2.py
+++ b/chord_metadata_service/chord/migrations/0013_migrate_datasets_to_v2.py
@@ -1,0 +1,17 @@
+from django.core.management import call_command
+from django.db import migrations
+
+
+def migrate_datasets_to_v2(apps, schema_editor):
+    call_command("migrate_datasets_to_v2")
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("chord", "0012_datasetv2"),
+    ]
+
+    operations = [
+        migrations.RunPython(migrate_datasets_to_v2, migrations.RunPython.noop),
+    ]

--- a/chord_metadata_service/experiments/migrations/0017_experiment_dataset_v2.py
+++ b/chord_metadata_service/experiments/migrations/0017_experiment_dataset_v2.py
@@ -38,7 +38,7 @@ ALTER TABLE experiments_experiment
 class Migration(migrations.Migration):
 
     dependencies = [
-        ("chord", "0012_datasetv2"),
+        ("chord", "0013_migrate_datasets_to_v2"),
         ("experiments", "0016_v13_2_0"),
     ]
 

--- a/chord_metadata_service/phenopackets/migrations/0019_phenopacket_dataset_v2.py
+++ b/chord_metadata_service/phenopackets/migrations/0019_phenopacket_dataset_v2.py
@@ -38,7 +38,7 @@ ALTER TABLE phenopackets_phenopacket
 class Migration(migrations.Migration):
 
     dependencies = [
-        ("chord", "0012_datasetv2"),
+        ("chord", "0013_migrate_datasets_to_v2"),
         ("phenopackets", "0018_v13_2_0"),
     ]
 


### PR DESCRIPTION
## Summary
- Add `chord/migrations/0013_migrate_datasets_to_v2` that runs the `migrate_datasets_to_v2` management command as a migration step, populating `chord_datasetv2` from legacy `Dataset` records
- Update `experiments/0017` and `phenopackets/0019` to depend on `0013` so FK constraints are only added after data is present, fixing `ForeignKeyViolation` on deploy to instances with existing data