### PR TITLE
fix(restapi): enforce CURIE pattern on ontology class id at ingest

### DIFF
--- a/chord_metadata_service/chord/tests/example_experiment.json
+++ b/chord_metadata_service/chord/tests/example_experiment.json
@@ -6,7 +6,7 @@
       "study_type": "Epigenomics",
       "experiment_type": "Other",
       "experiment_ontology": {
-          "id": "http://www.ebi.ac.uk/efo/EFO_0002692",
+          "id": "EFO:0002692",
           "label": "ChIP-seq"
       },
       "library_strategy": "ChIP-Seq",
@@ -71,7 +71,7 @@
       "study_type": "Epigenomics",
       "experiment_type": "Other",
       "experiment_ontology": {
-          "id": "http://www.ebi.ac.uk/efo/EFO_0002692",
+          "id": "EFO:0002692",
           "label": "ChIP-seq"
       },
       "library_strategy": "ChIP-Seq",

--- a/chord_metadata_service/chord/tests/example_experiment_bad_biosample.json
+++ b/chord_metadata_service/chord/tests/example_experiment_bad_biosample.json
@@ -6,7 +6,7 @@
       "study_type": "Epigenomics",
       "experiment_type": "Other",
       "experiment_ontology": {
-          "id": "http://www.ebi.ac.uk/efo/EFO_0002692",
+          "id": "EFO:0002692",
           "label": "ChIP-seq"
       },
       "library_strategy": "ChIP-Seq",

--- a/chord_metadata_service/chord/tests/example_phenopacket_2_v2.json
+++ b/chord_metadata_service/chord/tests/example_phenopacket_2_v2.json
@@ -51,7 +51,7 @@
       "id": "sample1",
       "individual_id": "patient1",
       "sampled_tissue": {
-        "id": "UBERON_0001256",
+        "id": "UBERON:0001256",
         "label": "wall of urinary bladder"
       },
       "histological_diagnosis": {

--- a/chord_metadata_service/chord/tests/example_phenopacket_v2.json
+++ b/chord_metadata_service/chord/tests/example_phenopacket_v2.json
@@ -82,7 +82,7 @@
       "id": "sample1",
       "individual_id": "patient1",
       "sampled_tissue": {
-        "id": "UBERON_0001256",
+        "id": "UBERON:0001256",
         "label": "wall of urinary bladder"
       },
       "histological_diagnosis": {

--- a/chord_metadata_service/experiments/tests/example_phenopackets.json
+++ b/chord_metadata_service/experiments/tests/example_phenopackets.json
@@ -56,7 +56,7 @@
             "individual_id": "ind:NA20509001",
             "description": "",
             "sampled_tissue": {
-                "id": "UBERON_0001256",
+                "id": "UBERON:0001256",
                 "label": "wall of urinary bladder"
             },
             "phenotypic_features": [],
@@ -225,7 +225,7 @@
             "individual_id": "ind:NA20509002",
             "description": "",
             "sampled_tissue": {
-                "id": "UBERON_0001256",
+                "id": "UBERON:0001256",
                 "label": "wall of urinary bladder"
             },
             "phenotypic_features": [],
@@ -368,7 +368,7 @@
             "individual_id": "ind:NA20509003",
             "description": "",
             "sampled_tissue": {
-                "id": "UBERON_0001256",
+                "id": "UBERON:0001256",
                 "label": "wall of urinary bladder"
             },
             "phenotypic_features": [],

--- a/chord_metadata_service/phenopackets/tests/constants.py
+++ b/chord_metadata_service/phenopackets/tests/constants.py
@@ -401,7 +401,7 @@ def valid_biosample_1(individual, procedure=VALID_PROCEDURE_1):
         individual_id=individual,
         description='This is a test biosample.',
         sampled_tissue={
-            "id": "UBERON_0001256",
+            "id": "UBERON:0001256",
             "label": "wall of urinary bladder"
         },
         taxonomy={
@@ -444,7 +444,7 @@ def valid_biosample_2(individual, procedure=VALID_PROCEDURE_2, **kwargs):
         sampled_tissue = kwargs["sampled_tissue"]
     else:
         sampled_tissue = {
-            "id": "UBERON_0001256",
+            "id": "UBERON:0001256",
             "label": "urinary bladder"
         }
 

--- a/chord_metadata_service/phenopackets/tests/test_models.py
+++ b/chord_metadata_service/phenopackets/tests/test_models.py
@@ -70,7 +70,7 @@ class BiosampleTest(ProjectTestCase):
 
     def test_get_sample_tissue_data(self):
         data = self.biosample_1.get_sample_tissue_data
-        self.assertEqual(data["reference"]["reference"], "UBERON_0001256")
+        self.assertEqual(data["reference"]["reference"], "UBERON:0001256")
         self.assertEqual(data["reference"]["display"], "wall of urinary bladder")
 
 

--- a/chord_metadata_service/restapi/schemas.py
+++ b/chord_metadata_service/restapi/schemas.py
@@ -1,3 +1,4 @@
+from bento_lib.ontologies.models import CURIE_PATTERN
 from django.conf import settings
 from . import descriptions
 from .description_utils import EXTRA_PROPERTIES, ONTOLOGY_CLASS as ONTOLOGY_CLASS_DESC
@@ -6,6 +7,7 @@ from .schema_utils import (
     DRAFT_07,
     SchemaTypes,
     base_type,
+    string_with_pattern,
     tag_ids_and_describe,
     named_one_of,
     sub_schema_uri,
@@ -40,7 +42,10 @@ ONTOLOGY_CLASS = tag_ids_and_describe(
         "$id": sub_schema_uri(phenopacket_base_uri, "ontology_class"),
         "title": "Ontology class schema",
         "type": "object",
-        "properties": {"id": base_type(SchemaTypes.STRING), "label": base_type(SchemaTypes.STRING)},
+        "properties": {
+            "id": string_with_pattern(CURIE_PATTERN, description="A CURIE-formatted ontology term ID."),
+            "label": base_type(SchemaTypes.STRING),
+        },
         "additionalProperties": False,
         "required": ["id", "label"],
     },
@@ -65,7 +70,7 @@ CURIE_SCHEMA = {
         "A CURIE string has the structure ``prefix``:``reference``, as defined by the W3C syntax."
     ),
     "type": "string",
-    "pattern": "^\\w[^:]*:.+$",
+    "pattern": CURIE_PATTERN,
     "additionalProperties": False,
 }
 

--- a/examples/experiments.json
+++ b/examples/experiments.json
@@ -5,7 +5,7 @@
       "study_type": "Epigenomics",
       "experiment_type": "Histone H3K27ac",
       "experiment_ontology": {
-          "id": "http://www.ebi.ac.uk/efo/EFO_0002692",
+          "id": "EFO:0002692",
           "label": "ChIP-seq"
       },
       "library_strategy": "ChIP-Seq",
@@ -64,7 +64,7 @@
       "experiment_type": "Histone H3K27ac",
       "experiment_ontology": [
         {
-          "id": "http://www.ebi.ac.uk/efo/EFO_0002692",
+          "id": "EFO:0002692",
           "label": "ChIP-seq"
         }
       ],


### PR DESCRIPTION
## Summary
- Non-CURIE ontology IDs (e.g. raw OBO IRIs like `http://purl.obolibrary.org/obo/OBI_0002117`) passed ingest validation but failed later at search/discovery time, since `bento_lib.ontologies.models.OntologyClass` enforces a strict CURIE pattern that katsu's own ingest schema never checked.
- `ONTOLOGY_CLASS["id"]` in `restapi/schemas.py` now reuses `bento_lib.ontologies.models.CURIE_PATTERN` as a single source of truth, so ingest and search validation agree.
- Fixed test fixtures that were themselves relying on the validation gap (underscore-style OBO ids, a raw EFO IRI).