### PR TITLE
feat(experiments): add batch/experimentresults endpoint (CSV + XLSX export)

### DIFF
--- a/chord_metadata_service/experiments/api_views.py
+++ b/chord_metadata_service/experiments/api_views.py
@@ -16,6 +16,7 @@ from chord_metadata_service.restapi.api_renderers import (
     PhenopacketsRenderer,
     ExperimentCSVRenderer,
     ExperimentResultCSVRenderer,
+    ExperimentResultXLSXRenderer,
     csv_fields_error_response,
 )
 from chord_metadata_service.restapi.constants import MODEL_ID_PATTERN
@@ -178,7 +179,12 @@ class ExperimentResultBatchViewSet(BentoAuthzScopedModelGenericListViewSet):
 
     serializer_class = ExperimentResultSerializer
     pagination_class = BatchResultsSetPagination
-    renderer_classes = (*api_settings.DEFAULT_RENDERER_CLASSES, PhenopacketsRenderer, ExperimentResultCSVRenderer)
+    renderer_classes = (
+        *api_settings.DEFAULT_RENDERER_CLASSES,
+        PhenopacketsRenderer,
+        ExperimentResultCSVRenderer,
+        ExperimentResultXLSXRenderer,
+    )
     content_negotiation_class = FormatInPostContentNegotiation
 
     data_type = DATA_TYPE_EXPERIMENT

--- a/chord_metadata_service/experiments/api_views.py
+++ b/chord_metadata_service/experiments/api_views.py
@@ -15,6 +15,7 @@ from chord_metadata_service.discovery.scope import get_request_discovery_scope
 from chord_metadata_service.restapi.api_renderers import (
     PhenopacketsRenderer,
     ExperimentCSVRenderer,
+    ExperimentResultCSVRenderer,
     csv_fields_error_response,
 )
 from chord_metadata_service.restapi.constants import MODEL_ID_PATTERN
@@ -164,6 +165,73 @@ class ExperimentResultViewSet(BentoAuthzScopedModelViewSet):
             .get_model_scoped_queryset(await get_request_discovery_scope(self.request))
             .order_by("id")
         )
+
+
+class ExperimentResultBatchViewSet(BentoAuthzScopedModelGenericListViewSet):
+    """
+    get:
+    Return a list of all existing experiment results
+
+    post:
+    return a list of experiment results based on a list of ids
+    """
+
+    serializer_class = ExperimentResultSerializer
+    pagination_class = BatchResultsSetPagination
+    renderer_classes = (*api_settings.DEFAULT_RENDERER_CLASSES, PhenopacketsRenderer, ExperimentResultCSVRenderer)
+    content_negotiation_class = FormatInPostContentNegotiation
+
+    data_type = DATA_TYPE_EXPERIMENT
+
+    async def _filtered_queryset(self, ids_list: list[str] | None = None):
+        # We pre-filter experiment results to the scope. This way, if they specify an ID outside the scope, it's
+        # just ignored - the requester won't even know if it exists.
+        queryset = ExperimentResult.get_model_scoped_queryset(await get_request_discovery_scope(self.request))
+
+        if ids_list:
+            queryset = queryset.filter(id__in=ids_list)
+
+        return queryset.order_by("id")
+
+    @async_to_sync
+    async def _get_filtered_queryset(self, ids_list: list[str] | None = None):
+        return await self._filtered_queryset(ids_list)
+
+    @async_to_sync
+    async def get_queryset(self):
+        # Note: cannot call self._get_filtered_queryset(...) here - it is itself wrapped in async_to_sync, and calling
+        # an async_to_sync-wrapped callable from within an already-running event loop (as we are here) raises a
+        # RuntimeError, so we call the underlying async method directly instead.
+        return await self._filtered_queryset(self.request.data.get("id", None))
+
+    def permission_from_request(self, request: DrfRequest):
+        if self.action in ("list", "create", "export_fields"):
+            # Here, "create" maps to the data query permission because we use create(..) (i.e., POST) as a way to run a
+            # query with a large body.
+            # TODO: distant future: replace with HTTP QUERY verb.
+            return P_QUERY_DATA
+        return None  # viewset not implemented for any other action
+
+    def list(self, request, *args, **kwargs):
+        if (err := csv_fields_error_response(request, ExperimentResultCSVRenderer)) is not None:
+            return err
+        return super().list(request, *args, **kwargs)
+
+    def create(self, request, *_args, **_kwargs):
+        """
+        Despite the name, this is a POST request for returning a list of experiment results. Since query parameters
+        have a maximum size, POST requests can be used for large batches.
+        """
+        if (err := csv_fields_error_response(request, ExperimentResultCSVRenderer)) is not None:
+            return err
+
+        queryset = self._get_filtered_queryset(request.data.get("id", []))
+        serializer = ExperimentResultSerializer(queryset, many=True)
+        return Response(serializer.data, status=status.HTTP_200_OK)
+
+    @action(detail=False, methods=["GET"])
+    def export_fields(self, _request: DrfRequest, *_args, **_kwargs):
+        return Response(ExperimentResultCSVRenderer.field_choices())
 
 
 @extend_schema(

--- a/chord_metadata_service/experiments/tests/test_api.py
+++ b/chord_metadata_service/experiments/tests/test_api.py
@@ -18,6 +18,7 @@ from chord_metadata_service.chord.tests.constants import (
 )
 from chord_metadata_service.chord.ingest import WORKFLOW_INGEST_FUNCTION_MAP
 from chord_metadata_service.chord.workflows.metadata import WORKFLOW_PHENOPACKETS_JSON, WORKFLOW_EXPERIMENTS_JSON
+from chord_metadata_service.experiments.models import ExperimentResult
 from chord_metadata_service.experiments.schemas import EXPERIMENT_SCHEMA
 from chord_metadata_service.logger import logger
 from chord_metadata_service.restapi.api_renderers import ExperimentCSVRenderer
@@ -244,6 +245,75 @@ class GetExperimentsAppApisTest(AuthzAPITestCase):
 
     def test_get_experiment_batch_csv_unknown_field_error(self):
         response = self.one_authz_get('/api/batch/experiments?format=csv&fields=not_a_real_field')
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertIn('not_a_real_field', response.json()['errors'][0]['message'])
+
+    def test_get_experiment_result_batch(self):
+        response = self.one_authz_get('/api/batch/experimentresults')
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        response_data = response.json()
+        self.assertEqual(response_data['count'], 4)
+        self.assertEqual(len(response_data['results']), 4)
+
+    def test_get_experiment_result_batch_forbidden(self):
+        response = self.one_no_authz_get('/api/batch/experimentresults')
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
+    def test_post_experiment_result_batch_no_data(self):
+        response = self.one_authz_post('/api/batch/experimentresults', format='json')
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(len(response.json()), 4)
+
+    def test_post_experiment_result_batch_with_ids(self):
+        er_id = ExperimentResult.objects.first().id
+        response = self.one_authz_post('/api/batch/experimentresults', {'id': [er_id]}, format='json')
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        response_data = response.json()
+        self.assertEqual(len(response_data), 1)
+        self.assertEqual(response_data[0]['id'], er_id)
+
+    def test_post_experiment_result_batch_with_unknown_ids(self):
+        # ExperimentResult uses an integer PK, so an out-of-range int (not a malformed non-numeric string) is the
+        # realistic "doesn't exist" case here.
+        response = self.one_authz_post('/api/batch/experimentresults', {'id': [999999]}, format='json')
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(len(response.json()), 0)
+
+    def test_post_experiment_result_batch_forbidden(self):
+        response = self.one_no_authz_post('/api/batch/experimentresults', format='json')
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
+    def test_post_experiment_result_batch_csv_selected_fields(self):
+        response = self.one_authz_post(
+            '/api/batch/experimentresults', {'format': 'csv', 'fields': ['id', 'file_format']}, format='json'
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        headers = next(csv.reader(io.StringIO(response.content.decode('utf-8'))))
+        self.assertEqual(headers, ['Id', 'File format'])
+
+    def test_experiment_result_export_fields_action(self):
+        response = self.one_authz_get('/api/batch/experimentresults/export_fields')
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        keys = [f['key'] for f in response.json()]
+        self.assertEqual(
+            keys,
+            ['id', 'description', 'filename', 'url', 'genome_assembly_id', 'file_format', 'data_output_type',
+             'usage', 'creation_date', 'created_by'],
+        )
+
+    def test_experiment_result_export_fields_action_forbidden(self):
+        response = self.one_no_authz_get('/api/batch/experimentresults/export_fields')
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
+    def test_post_experiment_result_batch_csv_unknown_field_error(self):
+        response = self.one_authz_post(
+            '/api/batch/experimentresults', {'format': 'csv', 'fields': ['id', 'not_a_real_field']}, format='json'
+        )
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertIn('not_a_real_field', response.json()['errors'][0]['message'])
+
+    def test_get_experiment_result_batch_csv_unknown_field_error(self):
+        response = self.one_authz_get('/api/batch/experimentresults?format=csv&fields=not_a_real_field')
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
         self.assertIn('not_a_real_field', response.json()['errors'][0]['message'])
 

--- a/chord_metadata_service/experiments/tests/test_api.py
+++ b/chord_metadata_service/experiments/tests/test_api.py
@@ -2,6 +2,7 @@ import csv
 import io
 import uuid
 
+import openpyxl
 from django.test import TestCase
 from django.urls import reverse
 from jsonschema.validators import Draft7Validator
@@ -290,6 +291,31 @@ class GetExperimentsAppApisTest(AuthzAPITestCase):
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         headers = next(csv.reader(io.StringIO(response.content.decode('utf-8'))))
         self.assertEqual(headers, ['Id', 'File format'])
+
+    def test_post_experiment_result_batch_xlsx_selected_fields(self):
+        response = self.one_authz_post(
+            '/api/batch/experimentresults', {'format': 'xlsx', 'fields': ['id', 'file_format']}, format='json'
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(
+            response['Content-Type'], 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet'
+        )
+        wb = openpyxl.load_workbook(io.BytesIO(response.content))
+        ws = wb.active
+        headers = [c.value for c in next(ws.iter_rows())]
+        self.assertEqual(headers, ['Id', 'File format'])
+
+    def test_get_experiment_result_batch_xlsx(self):
+        response = self.one_authz_get('/api/batch/experimentresults?format=xlsx')
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        wb = openpyxl.load_workbook(io.BytesIO(response.content))
+        ws = wb.active
+        headers = [c.value for c in next(ws.iter_rows())]
+        self.assertEqual(
+            headers,
+            ['Id', 'Description', 'Filename', 'Url', 'Genome assembly id', 'File format', 'Data output type',
+             'Usage', 'Creation date', 'Created by'],
+        )
 
     def test_experiment_result_export_fields_action(self):
         response = self.one_authz_get('/api/batch/experimentresults/export_fields')

--- a/chord_metadata_service/restapi/api_renderers.py
+++ b/chord_metadata_service/restapi/api_renderers.py
@@ -141,6 +141,7 @@ class PassThruXLSXRenderer(BaseRenderer):
 
     media_type = XLSX_MEDIA_TYPE
     format = "xlsx"
+    charset = None  # binary format - avoid DRF appending "; charset=utf-8" to the Content-Type header
 
     def render(self, data, accepted_media_type=None, renderer_context=None):
         return HttpResponse(data, content_type=XLSX_MEDIA_TYPE)  # XLSX should already be rendered as bytes here
@@ -241,38 +242,23 @@ class FieldRegistryRenderer(metaclass=ABCMeta):
     def get_dicts(self, data, columns: list[str]) -> list[dict[str, str]]:
         return [{key: self.field_registry[key].getter(row) for key in columns} for row in data]
 
-
-class KatsuCSVRenderer(FieldRegistryRenderer, JSONRenderer, metaclass=ABCMeta):
-    media_type = "text/csv"
-    format = "csv"
-
-    file_name: str = "data.csv"
-
-    def _generate_csv_response(self, data: list[dict[str, str]], columns: list[str]):
-        headers = {key: _column_label(key) for key in columns}
-
-        response = HttpResponse(content_type="text/csv")
-        response["Content-Disposition"] = f"attachment; filename='{self.file_name}'"
-
-        dict_writer = csv.DictWriter(response, fieldnames=columns)
-        dict_writer.writerow(headers)
-        dict_writer.writerows(data)
-
-        return response
+    def _build_response(self, rows: list[dict[str, str]], columns: list[str]):
+        """Subclasses turn selected rows/columns into the actual format-specific response body."""
+        raise NotImplementedError
 
     def render(self, data, accepted_media_type=None, renderer_context=None):
         columns = self.get_columns(renderer_context)
 
         if not data:
-            return self._generate_csv_response([], columns)
+            return self._build_response([], columns)
 
         response_obj = renderer_context.get("response") if renderer_context else None
         if response_obj is not None and response_obj.status_code != status.HTTP_200_OK:
-            # Error response: render as JSON instead of CSV. This is invoked either directly (renderer_context has
-            # no "response" - see discovery_matches, which never hits this branch: it only reaches render() on the
-            # success path, errors having already been returned earlier) or via a DRF Response's own rendering
-            # (renderer_context["response"] is that same Response, headers already fixed to text/csv by
-            # finalize_response before render() runs) - so we mutate its Content-Type in place and hand back raw
+            # Error response: render as JSON instead of CSV/XLSX. This is invoked either directly (renderer_context
+            # has no "response" - see discovery_matches, which never hits this branch: it only reaches render() on
+            # the success path, errors having already been returned earlier) or via a DRF Response's own rendering
+            # (renderer_context["response"] is that same Response, headers already fixed to the export content type
+            # by finalize_response before render() runs) - so we mutate its Content-Type in place and hand back raw
             # bytes for DRF to assign as the body, rather than building a whole separate HttpResponse that DRF
             # would just discard the headers of.
             response_obj["Content-Type"] = "application/json; charset=utf-8"
@@ -283,25 +269,41 @@ class KatsuCSVRenderer(FieldRegistryRenderer, JSONRenderer, metaclass=ABCMeta):
         if isinstance(data, dict):
             data = data["results"]
 
-        return self._generate_csv_response(self.get_dicts(data, columns), columns)
+        return self._build_response(self.get_dicts(data, columns), columns)
+
+
+class KatsuCSVRenderer(FieldRegistryRenderer, JSONRenderer, metaclass=ABCMeta):
+    media_type = "text/csv"
+    format = "csv"
+
+    file_name: str = "data.csv"
+
+    def _build_response(self, rows: list[dict[str, str]], columns: list[str]):
+        headers = {key: _column_label(key) for key in columns}
+
+        response = HttpResponse(content_type="text/csv")
+        response["Content-Disposition"] = f"attachment; filename='{self.file_name}'"
+
+        dict_writer = csv.DictWriter(response, fieldnames=columns)
+        dict_writer.writerow(headers)
+        dict_writer.writerows(rows)
+
+        return response
 
 
 class KatsuXLSXRenderer(FieldRegistryRenderer, BaseRenderer, metaclass=ABCMeta):
     """
     Renders a serialized queryset (via field_registry) as a single-sheet XLSX workbook - same columns/values/
-    ordering as the equivalent KatsuCSVRenderer. Used directly by discovery_matches; not wired into any DRF
-    viewset's renderer_classes.
+    ordering as the equivalent KatsuCSVRenderer.
     """
 
     media_type = XLSX_MEDIA_TYPE
     format = "xlsx"
+    charset = None  # binary format - avoid DRF appending "; charset=utf-8" to the Content-Type header
 
     file_name: str = "data.xlsx"
 
-    def render(self, data, accepted_media_type=None, renderer_context=None):
-        columns = self.get_columns(renderer_context)
-        rows = self.get_dicts(data, columns) if data else []
-
+    def _build_response(self, rows: list[dict[str, str]], columns: list[str]):
         wb = Workbook()
         ws = wb.active
         ws.title = "Export"

--- a/chord_metadata_service/restapi/urls.py
+++ b/chord_metadata_service/restapi/urls.py
@@ -32,6 +32,9 @@ router.register(r'project_json_schemas', chord_views.ProjectJsonSchemaViewSet)
 router.register(r"experiments", experiment_views.ExperimentViewSet, basename="experiments")
 router.register(r"experimentresults", experiment_views.ExperimentResultViewSet, basename="experimentresults")
 router.register(r"batch/experiments", experiment_views.ExperimentBatchViewSet, basename="batch/experiments")
+router.register(
+    r"batch/experimentresults", experiment_views.ExperimentResultBatchViewSet, basename="batch/experimentresults"
+)
 
 # Patients app urls
 router.register(r"individuals", individual_views.IndividualViewSet, basename="individuals")


### PR DESCRIPTION
## Summary
- `experiment_result` was the only entity with CSV/XLSX export (via `discovery_matches`) but no batch-by-ID endpoint of its own, unlike `individuals`/`biosamples`/`experiments`.
- Adds `ExperimentResultBatchViewSet` at `/api/batch/experimentresults`, mirroring `ExperimentBatchViewSet`:
  - `GET` - list all (unfiltered)
  - `POST {"id": [...]}` - filter to a specific ID list (unknown IDs silently dropped, matching sibling batch endpoints)
  - `POST {"format": "csv"|"xlsx", "fields": [...]}` - CSV or XLSX export with column selection
  - `GET /export_fields` - `{key, label}` column picker, same `csv_fields_error_response` 400-on-unknown-field validation as the other batch endpoints
- Also adds XLSX as an export option on this endpoint (`format=xlsx`, same `fields` selector/validation as CSV) - previously XLSX only existed on `discovery_matches`.

## Bug fixes surfaced along the way
Wiring `KatsuXLSXRenderer` into a real viewset (rather than only being called directly from `discovery_matches`) exposed two bugs in it:
- `render()` never unwrapped paginated `{"count", "results": [...]}` responses before iterating rows, unlike `KatsuCSVRenderer` - crashed on any paginated batch endpoint response.
- `BaseRenderer`'s default `charset='utf-8'` made DRF append `"; charset=utf-8"` to the XLSX Content-Type header once content-type assembly went through the normal `Response.rendered_content` path instead of being invoked directly.

Fixed by refactoring the shared `render()` flow (column selection, paginated-dict unwrapping, non-200 JSON error fallback) into the `FieldRegistryRenderer` mixin, with format-specific classes only implementing `_build_response(rows, columns)`. Same charset fix applied to `PassThruXLSXRenderer` for consistency.

## Notes
- `ExperimentResult` uses an integer PK (unlike the string IDs on `Individual`/`Biosample`/`Experiment`), so passing a non-numeric value in `id` raises rather than being silently ignored - pre-existing model behavior, not something this endpoint changes. Covered in tests with an out-of-range int instead.
- Based on `feature/csv-export-fields-picker` (not `develop`) since it reuses that branch's `ExperimentResultCSVRenderer`/`ExperimentResultXLSXRenderer`/`field_choices`/`csv_fields_error_response` infra.
