### PR TITLE
fix(patients): register XLSX renderer on batch/individuals

### DIFF
--- a/chord_metadata_service/patients/api_views.py
+++ b/chord_metadata_service/patients/api_views.py
@@ -41,6 +41,7 @@ from chord_metadata_service.phenopackets.serializers import PhenopacketSerialize
 from chord_metadata_service.restapi.api_renderers import (
     PhenopacketsRenderer,
     IndividualCSVRenderer,
+    IndividualXLSXRenderer,
     IndividualBentoSearchRenderer,
     csv_fields_error_response,
 )
@@ -189,6 +190,7 @@ class IndividualBatchViewSet(BentoAuthzScopedModelGenericListViewSet):
         *api_settings.DEFAULT_RENDERER_CLASSES,
         PhenopacketsRenderer,
         IndividualCSVRenderer,
+        IndividualXLSXRenderer,
         IndividualBentoSearchRenderer,
     )
     # Override to infer the renderer based on a `format` argument from the POST request body

--- a/chord_metadata_service/patients/tests/test_api.py
+++ b/chord_metadata_service/patients/tests/test_api.py
@@ -1,5 +1,6 @@
 import csv
 import io
+import openpyxl
 import random
 import uuid
 
@@ -441,6 +442,31 @@ class BatchIndividualsCSVTest(TestWithTwoIndividuals):
         )
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
         self.assertIn("not_a_real_field", response.json()["errors"][0]["message"])
+
+
+class BatchIndividualsXLSXTest(TestWithTwoIndividuals):
+    """Test for getting a batch of individuals as xlsx."""
+
+    def test_batch_individuals_xlsx_selected_fields(self):
+        response = self.one_authz_post(
+            reverse("batch/individuals"), json={"format": "xlsx", "fields": ["id", "sex"]}
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(
+            response["Content-Type"], "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
+        )
+        wb = openpyxl.load_workbook(io.BytesIO(response.content))
+        ws = wb.active
+        headers = [c.value for c in next(ws.iter_rows())]
+        self.assertEqual(headers, ["Id", "Sex"])
+
+    def test_post_batch_individuals_xlsx(self):
+        response = self.one_authz_post(reverse("batch/individuals"), json={"format": "xlsx"})
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        wb = openpyxl.load_workbook(io.BytesIO(response.content))
+        ws = wb.active
+        headers = [c.value for c in next(ws.iter_rows())]
+        self.assertEqual(headers, c.CSV_HEADER.split(","))
 
 
 class BatchIndividualsCSVTest1(TestWithTwoIndividuals):


### PR DESCRIPTION
## Summary
- `IndividualXLSXRenderer` was defined but never added to `IndividualBatchViewSet.renderer_classes`, so `GET/POST /batch/individuals` requests for `xlsx` (via `format` param or `Accept` header) silently fell back to JSON instead of returning a spreadsheet.
- Registers `IndividualXLSXRenderer` alongside the existing CSV/Phenopackets/BentoSearch renderers on the viewset.